### PR TITLE
Possible docx template example [Do not merge]

### DIFF
--- a/docx/docx.go
+++ b/docx/docx.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/opencontrol/doc-template"
 	"github.com/opencontrol/compliance-masonry/models"
+	"github.com/opencontrol/doc-template"
 )
 
 // Config contains data for docx template export configurations
@@ -29,11 +29,22 @@ func (config *Config) BuildDocx() error {
 	if err != nil {
 		return err
 	}
-	funcMap := template.FuncMap{"getControl": openControl.FormatControl}
+	funcMap := template.FuncMap{
+		"getControl":        openControl.FormatControl,
+		"getJustifications": openControl.GetJustifications,
+		"getComponent":      openControl.Components.Get,
+	}
 	docTemplate.AddFunctions(funcMap)
 	docTemplate.Parse()
 	docTemplate.Execute(config.ExportPath, nil)
 	return err
+}
+
+// GetJustifications returns a control formatted for docx
+func (openControl *OpenControlDocx) GetJustifications(standardControl string) models.Verifications {
+	standardKey, controlKey := SplitControl(standardControl)
+	justifications := openControl.Justifications.Get(standardKey, controlKey)
+	return justifications
 }
 
 // FormatControl returns a control formatted for docx


### PR DESCRIPTION
Currently the template engine only supports one way of getting control data. 
For example the tag below produces
```txt
{{ getControl "NIST-800-53@CM-2"}}
```
this:
```txt
Amazon Elastic Compute Cloud  
Justification in narrative form  
Covered By:  
- EC2 Verification 1 http://VerificationURL.com  
```

We could implement more complex functions in templates using code similar to the code in this branch to customize the way data is rendered. 
For example:
```txt
{{ with getJustifications “NIST-800-53@CM-2” }}
{{ range $justification := . }}
{{$justification}}
{{$justification.SatisfiesData.Narrative}}
{{len $justification.SatisfiesData.CoveredBy }}
{{range $coveredBy := $justification.SatisfiesData.CoveredBy}}
{{$coveredBy}}
{{end}}
{{end}}
{{end}}

```