### PR TITLE
Move to using codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Compliance Masonry
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/opencontrol/compliance-masonry)](https://goreportcard.com/report/github.com/opencontrol/compliance-masonry)
-[![Coverage Status](https://coveralls.io/repos/github/opencontrol/compliance-masonry/badge.svg?branch=master)](https://coveralls.io/github/opencontrol/compliance-masonry?branch=master)
+[![codecov.io](https://codecov.io/github/opencontrol/compliance-masonry/coverage.svg?branch=master)](https://codecov.io/github/opencontrol/compliance-masonry?branch=master)
 [![Circle CI](https://circleci.com/gh/opencontrol/compliance-masonry/tree/master.svg?style=svg)](https://circleci.com/gh/opencontrol/compliance-masonry/tree/master)
 [![Build status](https://ci.appveyor.com/api/projects/status/jjjo83ewacbwnthy/branch/master?svg=true)](https://ci.appveyor.com/project/opencontrol/compliance-masonry/branch/master)
 

--- a/circleci/coverage.sh
+++ b/circleci/coverage.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-cov_file=/home/ubuntu/coverage.out
+cov_file=/home/ubuntu/coverage.txt
 
 # Get the list of packages.
 pkgs=`go list $(/home/ubuntu/.go_workspace/bin/glide novendor)`
@@ -20,4 +20,4 @@ done
 
 go tool cover -func $cov_file
 
-/home/ubuntu/.go_workspace/bin/goveralls -coverprofile=$cov_file -service=circle-ci -repotoken=$COVERALLS_TOKEN
+mv $cov_file . && bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
For fork PRs, circleci will suppress the token to upload a coverage report. Codecov allows you to upload the report without a token because it has internal apis circleci.

Also, coveralls does not seem to be working recently as smoothly as usual lately.