### PR TITLE
Add `responsible_role` and parameters to `component` schema

### DIFF
--- a/docx/docx.go
+++ b/docx/docx.go
@@ -34,12 +34,23 @@ func (config *Config) BuildDocx() error {
 	funcMap := template.FuncMap{
 		"getAllControlSections": openControl.FormatControl,
 		"getControlSection":     openControl.FormatControl,
+		"getParameter":          openControl.FormatParameter,
+		"getResponsibleRole":    openControl.FormatResponsibleRoles,
 	}
 	docTemplate.AddFunctions(funcMap)
 	docTemplate.Parse()
 	docTemplate.Execute(config.ExportPath, nil)
 	return err
 }
+
+type componentInfoType int
+
+const (
+	noneInfo componentInfoType = iota
+	controlInfo
+	parameterInfo
+	responsibleRoleInfo
+)
 
 // createSectionsSet creates a set of section headers to do easy searching from the slice of string section keys
 func createSectionsSet(sections ...string) *set.Set {
@@ -50,20 +61,16 @@ func createSectionsSet(sections ...string) *set.Set {
 	return sectionsSet
 }
 
-// getComponentControlText will get the appropriate control text that is formatted for the word document.
-func getComponentControlText(justification models.Verification, component *models.Component, specifiedSections *set.Set) string {
-	var text string
-
+func getControlInfo(text string, justification models.Verification, component *models.Component, specifiedSections *set.Set) (string, bool) {
 	// Add the component name.
 	text = fmt.Sprintf("%s%s\n", text, component.Name)
-
-	// Determine if we want to get all of the sections or just one. If we specify exact sections, that means we do
-	// not want all and if we do not specify sections, it means we want all sections.
-	allSections := specifiedSections.Size() == 0
 
 	// foundText is a placeholder to indicate that we actually found text for the section.
 	foundText := false
 
+	// Determine if we want to get all of the sections or just one. If we specify exact sections, that means we do
+	// not want all and if we do not specify sections, it means we want all sections.
+	allSections := specifiedSections.Size() == 0
 	// Print out the narrative(s)
 	for _, section := range justification.SatisfiesData.Narrative {
 		if allSections {
@@ -90,18 +97,43 @@ func getComponentControlText(justification models.Verification, component *model
 			}
 		}
 	}
-
-	if !foundText {
-		text = fmt.Sprintf("%s%s\n", text, constants.WarningNoInformationAvailable)
-	}
-
-	return text
+	return text, foundText
 }
 
-// FormatControl returns a control formatted for docx
-func (openControl *OpenControlDocx) FormatControl(standardKey string, controlKey string, sectionKeys ...string) string {
-	sectionSet := createSectionsSet(sectionKeys...)
+func getParameterInfo(text string, justification models.Verification, component *models.Component, specifiedSections *set.Set) (string, bool) {
+	// Add the component name.
+	text = fmt.Sprintf("%s%s\n", text, component.Name)
+
+	// foundText is a placeholder to indicate that we actually found text for the section.
+	foundText := false
+
+	for _, parameter := range justification.SatisfiesData.Parameters {
+		// If section header exists, let's print it's corresponding text and not the header itself.
+		if specifiedSections.Has(parameter.Key){
+			text = fmt.Sprintf("%s%s\n", text, parameter.Text)
+			foundText = true
+		}
+	}
+	return text, foundText
+}
+
+func getResponsibleRoleInfo(text string, justification models.Verification, component *models.Component, specifiedSections *set.Set) (string, bool) {
+	// Add the component name.
+	text = fmt.Sprintf("%s%s: ", text, component.Name)
+	// Print out the component name and the responsible for that component.
+	if justification.SatisfiesData.ResponsibleRole != "" {
+		return fmt.Sprintf("%s%s\n", text, justification.SatisfiesData.ResponsibleRole), true
+	} else {
+		return text, false
+	}
+}
+
+// getComponentControlText will get the appropriate control text that is formatted for the word document.
+func (openControl *OpenControlDocx) getComponentText(infoType componentInfoType, standardKey string, controlKey string, sectionKeys ...string) string {
+
 	var text string
+	sectionSet := createSectionsSet(sectionKeys...)
+
 	openControl.Justifications.GetAndApply(standardKey, controlKey, func(selectJustifications models.Verifications) {
 		// In the case that no information was found period for the standard and control
 		if len(selectJustifications) == 0 {
@@ -111,9 +143,39 @@ func (openControl *OpenControlDocx) FormatControl(standardKey string, controlKey
 		for _, justification := range selectJustifications {
 			openControl.Components.GetAndApply(justification.ComponentKey, func(component *models.Component) {
 				// Get the Component Text
-				text = fmt.Sprintf("%s%s", text, getComponentControlText(justification, component, sectionSet))
+				var specificText string
+				var found bool
+				switch(infoType) {
+				case controlInfo:
+					specificText, found = getControlInfo(text, justification, component, sectionSet)
+				case parameterInfo:
+					specificText, found = getParameterInfo(text, justification, component, sectionSet)
+				case responsibleRoleInfo:
+					specificText, found = getResponsibleRoleInfo(text, justification, component, sectionSet)
+				}
+				if found {
+					text = fmt.Sprintf("%s%s", text, specificText)
+				} else {
+					text = fmt.Sprintf("%s%s\n", text, constants.WarningNoInformationAvailable)
+				}
 			})
 		}
 	})
+
 	return text
+}
+
+// FormatResponsibleRole fills in the responsible role for each component for a given standard and control.
+func (openControl *OpenControlDocx) FormatResponsibleRoles(standardKey string, controlKey string) string {
+	return openControl.getComponentText(responsibleRoleInfo, standardKey, controlKey, "")
+}
+
+// FormatParameter fills in the parameter for a given parameter, standard and control.
+func (openControl *OpenControlDocx) FormatParameter(standardKey string, controlKey string, sectionKeys ...string) string {
+	return openControl.getComponentText(parameterInfo, standardKey, controlKey, sectionKeys...)
+}
+
+// FormatControl returns a control formatted for docx
+func (openControl *OpenControlDocx) FormatControl(standardKey string, controlKey string, sectionKeys ...string) string {
+	return openControl.getComponentText(controlInfo, standardKey, controlKey, sectionKeys...)
 }

--- a/docx/docx_test.go
+++ b/docx/docx_test.go
@@ -17,6 +17,30 @@ import (
 )
 
 var _ = Describe("Docx", func() {
+	DescribeTable("FormatParameter", func(standard string, control string, expectedData string, sectionKeys ...string) {
+		openControl := docx.OpenControlDocx{
+			OpenControl: models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), ""),
+		}
+		actualData := openControl.FormatParameter(standard, control, sectionKeys...)
+		assert.Equal(GinkgoT(), expectedData, actualData)
+	},
+		Entry("openControl.FormatParameter(NIST-800-53@CM-2)", "NIST-800-53", "CM-2", "", "a"),
+		Entry("openControl.FormatParameter(PCI-DSS-MAY-2015@2.1)", "PCI-DSS-MAY-2015", "1.1", "Amazon Elastic Compute Cloud:\nParameter A for 1.1\n", "a"),
+		Entry("openControl.FormatParameter(BogusControl@Nothing)", "BogusControl", "Nothing", "", "a"),
+	)
+
+	DescribeTable("FormatResponsibleRoles", func(standard string, control string, expectedData string) {
+		openControl := docx.OpenControlDocx{
+			OpenControl: models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), ""),
+		}
+		actualData := openControl.FormatResponsibleRoles(standard, control)
+		assert.Equal(GinkgoT(), expectedData, actualData)
+	},
+		Entry("openControl.FormatResponsibleRoles(NIST-800-53@CM-2)", "NIST-800-53", "CM-2", ""),
+		Entry("openControl.FormatResponsibleRoles(PCI-DSS-MAY-2015@2.1)", "PCI-DSS-MAY-2015", "2.1", "Amazon Elastic Compute Cloud: 2.1 Staff\n"),
+		Entry("openControl.FormatResponsibleRoles(BogusControl@Nothing)", "BogusControl", "Nothing", ""),
+	)
+
 	DescribeTable("FormatControl", func(standard string, control string, expectedData string, sectionKeys ...string) {
 		openControl := docx.OpenControlDocx{
 			OpenControl: models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), ""),

--- a/fixtures/component_fixtures/EC2/component.yaml
+++ b/fixtures/component_fixtures/EC2/component.yaml
@@ -25,6 +25,12 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1"
+    - key: "b"
+      text: "Parameter B for 1.1"
+  responsible_role: "1.1 Staff"
   narrative:
     - key: "a"
       text: "Justification in narrative form A for 1.1"
@@ -39,12 +45,19 @@ satisfies:
       text: "Justification in narrative form A for 1.1.1"
     - key: "b"
       text: "Justification in narrative form B for 1.1.1"
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1.1"
+    - key: "b"
+      text: "Parameter B for 1.1.1"
+  responsible_role: "1.1.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 - control_key: 2.1
   covered_by: []
   implementation_status: partial
   narrative:
     - text: "Justification in narrative form for 2.1"
+  responsible_role: "2.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 schema_version: 3.0.0
 verifications:

--- a/fixtures/component_fixtures/EC2WithKey/component.yaml
+++ b/fixtures/component_fixtures/EC2WithKey/component.yaml
@@ -26,6 +26,12 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1"
+    - key: "b"
+      text: "Parameter B for 1.1"
+  responsible_role: "1.1 Staff"
   narrative:
     - key: "a"
       text: "Justification in narrative form A for 1.1"
@@ -40,12 +46,19 @@ satisfies:
       text: "Justification in narrative form A for 1.1.1"
     - key: "b"
       text: "Justification in narrative form B for 1.1.1"
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1.1"
+    - key: "b"
+      text: "Parameter B for 1.1.1"
+  responsible_role: "1.1.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 - control_key: 2.1
   covered_by: []
   implementation_status: partial
   narrative:
     - text: "Justification in narrative form for 2.1"
+  responsible_role: "2.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 schema_version: 3.0.0
 verifications:

--- a/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-1.1.1.md
+++ b/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-1.1.1.md
@@ -2,4 +2,11 @@
 ##A formal process for approving and testing all network connections and changes to the firewall and router configurations
 
 #### Amazon Elastic Compute Cloud
-No information available for component
+
+##### Responsible Role: 1.1.1 Staff
+
+##### a
+Justification in narrative form A for 1.1.1
+
+##### b
+Justification in narrative form B for 1.1.1

--- a/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-1.1.md
+++ b/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-1.1.md
@@ -3,6 +3,8 @@
 
 #### Amazon Elastic Compute Cloud
 
+##### Responsible Role: 1.1 Staff
+
 ##### a
 Justification in narrative form A for 1.1
 

--- a/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-2.1.md
+++ b/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-2.1.md
@@ -2,4 +2,6 @@
 ##Always change vendor-supplied defaults and remove or disable unnecessary default accounts before installing a system on the network.
 
 #### Amazon Elastic Compute Cloud
+
+##### Responsible Role: 2.1 Staff
 Justification in narrative form for 2.1

--- a/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-1.1.1.md
+++ b/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-1.1.1.md
@@ -3,6 +3,8 @@
 
 #### Amazon Elastic Compute Cloud
 
+##### Responsible Role: 1.1.1 Staff
+
 ##### a
 Justification in narrative form A for 1.1.1
 

--- a/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-1.1.md
+++ b/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-1.1.md
@@ -3,6 +3,8 @@
 
 #### Amazon Elastic Compute Cloud
 
+##### Responsible Role: 1.1 Staff
+
 ##### a
 Justification in narrative form A for 1.1
 

--- a/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-2.1.md
+++ b/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-2.1.md
@@ -2,4 +2,6 @@
 ##Always change vendor-supplied defaults and remove or disable unnecessary default accounts before installing a system on the network.
 
 #### Amazon Elastic Compute Cloud
+
+##### Responsible Role: 2.1 Staff
 Justification in narrative form for 2.1

--- a/fixtures/opencontrol_fixtures/components/EC2/component.yaml
+++ b/fixtures/opencontrol_fixtures/components/EC2/component.yaml
@@ -25,6 +25,12 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1"
+    - key: "b"
+      text: "Parameter B for 1.1"
+  responsible_role: "1.1 Staff"
   narrative:
     - key: "a"
       text: "Justification in narrative form A for 1.1"
@@ -34,12 +40,24 @@ satisfies:
 - control_key: 1.1.1
   covered_by: []
   implementation_status: partial
+  narrative:
+    - key: "a"
+      text: "Justification in narrative form A for 1.1.1"
+    - key: "b"
+      text: "Justification in narrative form B for 1.1.1"
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1.1"
+    - key: "b"
+      text: "Parameter B for 1.1.1"
+  responsible_role: "1.1.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 - control_key: 2.1
   covered_by: []
   implementation_status: partial
   narrative:
     - text: "Justification in narrative form for 2.1"
+  responsible_role: "2.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 schema_version: 3.0.0
 verifications:

--- a/fixtures/opencontrol_fixtures_complete/components/EC2/component.yaml
+++ b/fixtures/opencontrol_fixtures_complete/components/EC2/component.yaml
@@ -18,6 +18,32 @@ satisfies:
     - key: "b"
       text: "Justification in narrative form B for CM-2"
   standard_key: NIST-800-53
+- control_key: AC-2
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
+  implementation_status: partial
+  narrative:
+    - key: "a"
+      text: "Justification in narrative form A for AC-2"
+    - key: "b"
+      text: "Justification in narrative form B for AC-2"
+  standard_key: NIST-800-53
+- control_key: AC-6
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
+  implementation_status: partial
+  narrative:
+    - key: "a"
+      text: "Justification in narrative form A for AC-6"
+    - key: "b"
+      text: "Justification in narrative form B for AC-6"
+  standard_key: NIST-800-53
 - control_key: 1.1
   covered_by:
   - verification_key: EC2_Verification_1
@@ -25,17 +51,17 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  narrative:
+    - key: "a"
+      text: "Justification in narrative form A for 1.1"
+    - key: "b"
+      text: "Justification in narrative form B for 1.1"
   parameters:
     - key: "a"
       text: "Parameter A for 1.1"
     - key: "b"
       text: "Parameter B for 1.1"
   responsible_role: "1.1 Staff"
-  narrative:
-    - key: "a"
-      text: "Justification in narrative form A for 1.1"
-    - key: "b"
-      text: "Justification in narrative form B for 1.1"
   standard_key: PCI-DSS-MAY-2015
 - control_key: 1.1.1
   covered_by: []
@@ -45,20 +71,14 @@ satisfies:
       text: "Justification in narrative form A for 1.1.1"
     - key: "b"
       text: "Justification in narrative form B for 1.1.1"
-  parameters:
-    - key: "a"
-      text: "Parameter A for 1.1.1"
-    - key: "b"
-      text: "Parameter B for 1.1.1"
-  responsible_role: "1.1.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 - control_key: 2.1
   covered_by: []
   implementation_status: partial
   narrative:
     - text: "Justification in narrative form for 2.1"
-  responsible_role: "2.1 Staff"
   standard_key: PCI-DSS-MAY-2015
+  responsible_role: "2.1 Staff"
 schema_version: 3.0.0
 verifications:
 - key: EC2_Verification_2

--- a/fixtures/opencontrol_fixtures_complete/components/EC2/component.yaml
+++ b/fixtures/opencontrol_fixtures_complete/components/EC2/component.yaml
@@ -18,32 +18,6 @@ satisfies:
     - key: "b"
       text: "Justification in narrative form B for CM-2"
   standard_key: NIST-800-53
-- control_key: AC-2
-  covered_by:
-  - verification_key: EC2_Verification_1
-  - component_key: UAA
-    system_key: CloudFoundry
-    verification_key: UAA_Verification_1
-  implementation_status: partial
-  narrative:
-    - key: "a"
-      text: "Justification in narrative form A for AC-2"
-    - key: "b"
-      text: "Justification in narrative form B for AC-2"
-  standard_key: NIST-800-53
-- control_key: AC-6
-  covered_by:
-  - verification_key: EC2_Verification_1
-  - component_key: UAA
-    system_key: CloudFoundry
-    verification_key: UAA_Verification_1
-  implementation_status: partial
-  narrative:
-    - key: "a"
-      text: "Justification in narrative form A for AC-6"
-    - key: "b"
-      text: "Justification in narrative form B for AC-6"
-  standard_key: NIST-800-53
 - control_key: 1.1
   covered_by:
   - verification_key: EC2_Verification_1
@@ -51,6 +25,12 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1"
+    - key: "b"
+      text: "Parameter B for 1.1"
+  responsible_role: "1.1 Staff"
   narrative:
     - key: "a"
       text: "Justification in narrative form A for 1.1"
@@ -65,12 +45,19 @@ satisfies:
       text: "Justification in narrative form A for 1.1.1"
     - key: "b"
       text: "Justification in narrative form B for 1.1.1"
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1.1"
+    - key: "b"
+      text: "Parameter B for 1.1.1"
+  responsible_role: "1.1.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 - control_key: 2.1
   covered_by: []
   implementation_status: partial
   narrative:
     - text: "Justification in narrative form for 2.1"
+  responsible_role: "2.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 schema_version: 3.0.0
 verifications:

--- a/fixtures/opencontrol_fixtures_with_markdown/components/EC2/component.yaml
+++ b/fixtures/opencontrol_fixtures_with_markdown/components/EC2/component.yaml
@@ -25,6 +25,12 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1"
+    - key: "b"
+      text: "Parameter B for 1.1"
+  responsible_role: "1.1 Staff"
   narrative:
     - key: "a"
       text: "Justification in narrative form A for 1.1"
@@ -39,12 +45,19 @@ satisfies:
       text: "Justification in narrative form A for 1.1.1"
     - key: "b"
       text: "Justification in narrative form B for 1.1.1"
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1.1"
+    - key: "b"
+      text: "Parameter B for 1.1.1"
+  responsible_role: "1.1.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 - control_key: 2.1
   covered_by: []
   implementation_status: partial
   narrative:
     - text: "Justification in narrative form for 2.1"
+  responsible_role: "2.1 Staff"
   standard_key: PCI-DSS-MAY-2015
 schema_version: 3.0.0
 verifications:

--- a/gitbook/gitbookCertification.go
+++ b/gitbook/gitbookCertification.go
@@ -22,10 +22,16 @@ func (openControl *OpenControlGitBook) exportControl(control *ControlGitbook) (s
 		for _, justification := range selectJustifications {
 			openControl.Components.GetAndApply(justification.ComponentKey, func(component *models.Component) {
 				text = fmt.Sprintf("%s\n#### %s\n", text, component.Name)
+
+				if justification.SatisfiesData.ResponsibleRole != "" {
+					text = fmt.Sprintf("%s\n##### Responsible Role: %s\n", text, justification.SatisfiesData.ResponsibleRole)
+				}
+
 				if len(justification.SatisfiesData.Narrative) == 0 {
 					text = fmt.Sprintf("%s%s\n", text, constants.WarningNoInformationAvailable)
 					return
 				}
+
 				for _, narrative := range justification.SatisfiesData.Narrative {
 					if narrative.Key != "" {
 						text = fmt.Sprintf("%s\n##### %s\n", text, narrative.Key)

--- a/models/components.go
+++ b/models/components.go
@@ -125,13 +125,22 @@ type SatisfiesList []Satisfies
 // This struct is a one-to-one mapping of a `satisfies` item in the component.yaml schema
 // https://github.com/opencontrol/schemas#component-yaml
 type Satisfies struct {
-	ControlKey  string             `yaml:"control_key" json:"control_key"`
-	StandardKey string             `yaml:"standard_key" json:"standard_key"`
-	Narrative   []NarrativeSection `yaml:"narrative" json:"narrative"`
-	CoveredBy   CoveredByList      `yaml:"covered_by" json:"covered_by"`
+	ControlKey      string             `yaml:"control_key" json:"control_key"`
+	StandardKey     string             `yaml:"standard_key" json:"standard_key"`
+	ResponsibleRole string             `yaml:"responsible_role" json:"responsible_role"`
+	Parameters      []Section          `yaml:"parameters" json:"parameters"`
+	Narrative       []NarrativeSection `yaml:"narrative" json:"narrative"`
+	CoveredBy       CoveredByList      `yaml:"covered_by" json:"covered_by"`
 }
 
-// NarrativeSection contains the key and text for a particular narrative section.
+// Section contains the key and text for a particular section. Both are required.
+type Section struct {
+	Key  string `yaml:"key" json:"key"`
+	Text string `yaml:"text" json:"text"`
+}
+
+// NarrativeSection contains the key and text for a particular section.
+// NarrativeSection can omit the key.
 type NarrativeSection struct {
 	Key  string `yaml:"key,omitempty" json:"key,omitempty"`
 	Text string `yaml:"text" json:"text"`

--- a/models/components_test.go
+++ b/models/components_test.go
@@ -20,6 +20,43 @@ type componentTestError struct {
 	expectedError error
 }
 
+var regularSatisfiesList = SatisfiesList{
+	{
+		Narrative: []NarrativeSection{
+			NarrativeSection{Key: "a", Text: "Justification in narrative form A for CM-2"},
+			NarrativeSection{Key: "b", Text: "Justification in narrative form B for CM-2"},
+		},
+	},
+	{
+		Narrative: []NarrativeSection{
+			NarrativeSection{Key: "a", Text: "Justification in narrative form A for 1.1"},
+			NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1"},
+		},
+		Parameters: []Section{
+			Section{Key: "a", Text: "Parameter A for 1.1"},
+			Section{Key: "b", Text: "Parameter B for 1.1"},
+		},
+		ResponsibleRole: "1.1 Staff",
+	},
+	{
+		Narrative: []NarrativeSection{
+			NarrativeSection{Key: "a", Text: "Justification in narrative form A for 1.1.1"},
+			NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1.1"},
+		},
+		Parameters: []Section{
+			Section{Key: "a", Text: "Parameter A for 1.1.1"},
+			Section{Key: "b", Text: "Parameter B for 1.1.1"},
+		},
+		ResponsibleRole: "1.1.1 Staff",
+	},
+	{
+		Narrative: []NarrativeSection{
+			NarrativeSection{Text: "Justification in narrative form for 2.1"},
+		},
+		ResponsibleRole: "2.1 Staff",
+	},
+}
+
 var componentTests = []componentTest{
 	// Check that a component without a key loads correctly, uses the key of its directory and loads correctly
 	{
@@ -29,31 +66,7 @@ var componentTests = []componentTest{
 			Key:           "EC2",
 			References:    &GeneralReferences{{}},
 			Verifications: &VerificationReferences{{}, {}},
-			Satisfies: &SatisfiesList{
-				{
-					Narrative: []NarrativeSection{
-						NarrativeSection{Key: "a", Text: "Justification in narrative form A for CM-2"},
-						NarrativeSection{Key: "b", Text: "Justification in narrative form B for CM-2"},
-					},
-				},
-				{
-					Narrative: []NarrativeSection{
-						NarrativeSection{Key: "a", Text: "Justification in narrative form A for 1.1"},
-						NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1"},
-					},
-				},
-				{
-					Narrative: []NarrativeSection{
-						NarrativeSection{Key: "a", Text: "Justification in narrative form A for 1.1.1"},
-						NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1.1"},
-					},
-				},
-				{
-					Narrative: []NarrativeSection{
-						NarrativeSection{Text: "Justification in narrative form for 2.1"},
-					},
-				},
-			},
+			Satisfies:     &regularSatisfiesList,
 			SchemaVersion: semver.MustParse("3.0.0"),
 		},
 	},
@@ -65,31 +78,7 @@ var componentTests = []componentTest{
 			Key:           "EC2",
 			References:    &GeneralReferences{{}},
 			Verifications: &VerificationReferences{{}, {}},
-			Satisfies: &SatisfiesList{
-				{
-					Narrative: []NarrativeSection{
-						NarrativeSection{Key: "a", Text: "Justification in narrative form A for CM-2"},
-						NarrativeSection{Key: "b", Text: "Justification in narrative form B for CM-2"},
-					},
-				},
-				{
-					Narrative: []NarrativeSection{
-						NarrativeSection{Key: "a", Text: "Justification in narrative form A for 1.1"},
-						NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1"},
-					},
-				},
-				{
-					Narrative: []NarrativeSection{
-						NarrativeSection{Key: "a", Text: "Justification in narrative form A for 1.1.1"},
-						NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1.1"},
-					},
-				},
-				{
-					Narrative: []NarrativeSection{
-						NarrativeSection{Text: "Justification in narrative form for 2.1"},
-					},
-				},
-			},
+			Satisfies:     &regularSatisfiesList,
 			SchemaVersion: semver.MustParse("3.0.0"),
 		},
 	},
@@ -105,10 +94,12 @@ func testSet(example componentTest, actual *Component, t *testing.T) {
 	// Check that the schema version was loaded
 	assert.Equal(t, example.expected.SchemaVersion, actual.SchemaVersion)
 
-	// Check that the narrative equals
+	// Check that the narrative, responsible role, and parameters equals
 	if assert.Equal(t, example.expected.Satisfies.Len(), actual.Satisfies.Len()) {
 		for idx, _ := range *actual.Satisfies {
 			assert.Equal(t, (*example.expected.Satisfies)[idx].Narrative, (*actual.Satisfies)[idx].Narrative)
+			assert.Equal(t, (*example.expected.Satisfies)[idx].ResponsibleRole, (*actual.Satisfies)[idx].ResponsibleRole)
+			assert.Equal(t, (*example.expected.Satisfies)[idx].Parameters, (*actual.Satisfies)[idx].Parameters)
 		}
 	}
 


### PR DESCRIPTION
Gitbook does not print out the parameters because it does not make sense to print them out.

Docx Template:
![image](https://cloud.githubusercontent.com/assets/7788930/15583842/8a9de3e4-2345-11e6-8808-41d548631fe8.png)

Filled in Template:
![image](https://cloud.githubusercontent.com/assets/7788930/15583865/9d14eb9e-2345-11e6-9925-8471e3c33909.png)
