### PR TITLE
Enable semver instead of float32

### DIFF
--- a/fixtures/component_fixtures/common/EC2VersionNotSemver/component.yaml
+++ b/fixtures/component_fixtures/common/EC2VersionNotSemver/component.yaml
@@ -14,7 +14,7 @@ satisfies:
   implementation_status: partial
   narrative: Justification in narrative form
   standard_key: NIST-800-53
-schema_version: 1.0.0
+schema_version: 1.0
 verifications:
 - key: EC2_Verification_2
   name: EC2 Governor 2

--- a/gitbook/gitbookComponents_test.go
+++ b/gitbook/gitbookComponents_test.go
@@ -5,6 +5,7 @@ import (
 
 	v2 "github.com/opencontrol/compliance-masonry/models/components/versions/2_0_0"
 	"github.com/opencontrol/compliance-masonry/models/common"
+	"github.com/blang/semver"
 )
 
 type componentExportTest struct {
@@ -22,7 +23,7 @@ var componentExportTests = []componentExportTest{
 			References:    common.GeneralReferences{{}},
 			Verifications: common.VerificationReferences{{}},
 			Satisfies:     nil,
-			SchemaVersion: 2.0,
+			SchemaVersion: semver.MustParse("2.0.0"),
 		},
 		"EC2.md",
 		"# Amazon Elastic Compute Cloud\n## References\n* []()\n## Verifications\n* []()\n",

--- a/models/components/README.md
+++ b/models/components/README.md
@@ -13,7 +13,21 @@ Now you must implement the [interfaces](versions/base/component.go) inside your 
 
 In the case that you want to change how much access you want to give externally, you will need to edit the methods on the [`interfaces`](versions/base/component.go).
 
-*TODO: Future patches will enable 1) more component.yaml and 2) using multiple versions. More details to come then.*
+### Adding A New Version
+
+1. Create a folder `versions/X_Y_Z` where the `X_Y_Z` is the version in semver notation.
+1. Create your Component struct and any other structs that will implement the different interfaces inside [here](versions/base/component.go).
+1. Add another variable to represent your version inside of [versions/parse.go](versions/parse.go)
+1. Add a check in the switch-case block for your new version that is represented by the variable created in step 3.
+    1. Follow the same logic seen in the other versions inside the switch-case block.
+1. Add tests case fixtures with valid and invalid data for your version along with the other fixtures.
+1. Add those cases to the [versions/parse_test.go](versions/parse_test.go)
+
+
+### Editing The Interface
+
+1. Change the interface(s) inside of [`interfaces`](versions/base/component.go).
+1. Change the implementations for all the component versions (located in `versions`) to accomodate the interface changes.
 
 For details on the component scheams, consult [the schemas repository](https://github.com/opencontrol/schemas)
 

--- a/models/components/README.md
+++ b/models/components/README.md
@@ -17,16 +17,16 @@ In the case that you want to change how much access you want to give externally,
 
 1. Create a folder `versions/X_Y_Z` where the `X_Y_Z` is the version in semver notation.
 1. Create your Component struct and any other structs that will implement the different interfaces inside [here](versions/base/component.go).
-1. Add another variable to represent your version inside of [versions/parse.go](versions/parse.go)
+1. Add another variable to represent your version inside of [`versions/parse.go`](versions/parse.go)
 1. Add a check in the switch-case block for your new version that is represented by the variable created in step 3.
     1. Follow the same logic seen in the other versions inside the switch-case block.
 1. Add tests case fixtures with valid and invalid data for your version along with the other fixtures.
-1. Add those cases to the [versions/parse_test.go](versions/parse_test.go)
+1. Add those cases to the [`versions/parse_test.go`](versions/parse_test.go)
 
 
 ### Editing The Interface
 
-1. Change the interface(s) inside of [`interfaces`](versions/base/component.go).
+1. Change the interface(s) inside of [interfaces](versions/base/component.go).
 1. Change the implementations for all the component versions (located in `versions`) to accomodate the interface changes.
 
 For details on the component scheams, consult [the schemas repository](https://github.com/opencontrol/schemas)

--- a/models/components/versions/2_0_0/component.go
+++ b/models/components/versions/2_0_0/component.go
@@ -3,6 +3,7 @@ package component
 import (
 	"github.com/opencontrol/compliance-masonry/models/components/versions/base"
 	"github.com/opencontrol/compliance-masonry/models/common"
+	"github.com/blang/semver"
 )
 
 // Component struct is an individual component requiring documentation
@@ -13,7 +14,7 @@ type Component struct {
 	References    common.GeneralReferences      `yaml:"references" json:"references"`
 	Verifications common.VerificationReferences `yaml:"verifications" json:"verifications"`
 	Satisfies     []Satisfies          `yaml:"satisfies" json:"satisfies"`
-	SchemaVersion float32                 `yaml:"schema_version" json:"schema_version"`
+	SchemaVersion semver.Version                 `yaml:"-" json:"-"`
 }
 
 func (c Component) GetName() string {
@@ -45,8 +46,12 @@ func (c Component) GetAllSatisfies() []base.Satisfies {
 	return baseSatisfies
 }
 
-func (c Component) GetVersion() float32 {
+func (c Component) GetVersion() semver.Version {
 	return c.SchemaVersion
+}
+
+func (c *Component) SetVersion(version semver.Version) {
+	c.SchemaVersion = version
 }
 
 // Satisfies struct contains data demonstrating why a specific component meets

--- a/models/components/versions/2_0_0/component_test.go
+++ b/models/components/versions/2_0_0/component_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"github.com/opencontrol/compliance-masonry/models/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/blang/semver"
 )
 
 func TestComponentGetterAndSetter(t *testing.T) {
@@ -13,7 +14,7 @@ func TestComponentGetterAndSetter(t *testing.T) {
 		References:    common.GeneralReferences{{}},
 		Verifications: common.VerificationReferences{{}, {}},
 		Satisfies:     []Satisfies{{}, {}, {}, {}},
-		SchemaVersion: 2.0,
+		SchemaVersion: semver.MustParse("2.0.0"),
 	}
 	assert.Equal(t, "EC2", component.GetKey())
 	assert.Equal(t, "Amazon Elastic Compute Cloud", component.GetName())
@@ -21,7 +22,9 @@ func TestComponentGetterAndSetter(t *testing.T) {
 	assert.Equal(t, "FooKey", component.GetKey())
 	assert.Equal(t, &common.GeneralReferences{{}}, component.GetReferences())
 	assert.Equal(t, &common.VerificationReferences{{}, {}}, component.GetVerifications())
-	assert.Equal(t, float32(2.0), component.GetVersion())
+	assert.Equal(t, semver.MustParse("2.0.0"), component.GetVersion())
+	component.SetVersion(semver.MustParse("3.0.0"))
+	assert.Equal(t, semver.MustParse("3.0.0"), component.GetVersion())
 	testSatisfies := []Satisfies{{}, {}, {}, {}}
 	assert.Equal(t, len(testSatisfies), len(component.GetAllSatisfies()))
 	for idx, satisfies := range component.GetAllSatisfies() {

--- a/models/components/versions/base/component.go
+++ b/models/components/versions/base/component.go
@@ -2,6 +2,9 @@ package base
 
 import (
 	"github.com/opencontrol/compliance-masonry/models/common"
+	"github.com/blang/semver"
+	"fmt"
+	"github.com/opencontrol/compliance-masonry/tools/constants"
 )
 
 type Component interface {
@@ -11,7 +14,8 @@ type Component interface {
 	GetAllSatisfies() []Satisfies
 	GetVerifications() *common.VerificationReferences
 	GetReferences() *common.GeneralReferences
-	GetVersion() float32
+	GetVersion() semver.Version
+	SetVersion(semver.Version)
 }
 
 type Satisfies interface {
@@ -21,8 +25,89 @@ type Satisfies interface {
 	GetCoveredBy() common.CoveredByList
 }
 
+func NewBaseComponentParseError(message string) BaseComponentParseError {
+	return BaseComponentParseError{message}
+}
+
+// BaseComponentParseError is the type of error that will be returned if the parsing failed for ONLY the `Base` struct.
+type BaseComponentParseError struct {
+	message string
+}
+
+func (b BaseComponentParseError) Error() string {
+	return b.message
+}
+
 // Base is the bare minimum that every component YAML will have and is used to find the schema version.
 // Complete implementations of component do not need to embed this struct or put it as a field in the component.
+// When this struct is used in the ParseComponent function, it will transfer the version from this struct to the
+// final component struct via SetVersion.
 type Base struct {
-	SchemaVersion float32 `yaml:"schema_version" json:"schema_version"`
+	SchemaVersion semver.Version `yaml:"-" json:"-"`
+}
+
+// UnmarshalYAML is a overridden implementation of YAML parsing the component.yaml
+// This method is similar to the one found here: http://choly.ca/post/go-json-marshalling/
+// This is necessary because we want to have backwards compatibility with parsing the old types of version 2.0
+// (type =float).
+// To compensate for that, we have to hand roll our own UnmarshalYAML that can decide what to do for parsing
+// the older version of type float and converting it into semver. In addition, we will use this logic to parse strings
+// into semver.
+func (b *Base) UnmarshalYAML(unmarshal func(v interface{}) error) error {
+	// When we call "unmarshal" callback on an object, it will call that object's "UnmarshalYAML" if defined.
+	// Since we are currently in the implementation of Component's "UnmarshalYAML", when finally we call
+	// unmarshal again, if it's on type Component, we would end up in a recursive infinite loop.
+	// To prevent this, we create a separate type, called Alias.
+	type Alias Base
+	// Create an anonymous struct with an interface{} type for the schema_version that we want to parse
+	aux := &struct {
+		SchemaVersion interface{} `yaml:"schema_version" json:"schema_version"`
+		Alias         `yaml:",inline"`
+	}{
+		Alias: (Alias)(*b),
+	}
+
+	// Call unmarshal on the new Alias type. Don't return the error yet because we want to gather more information
+	// if we can below.
+	err := unmarshal(&aux)
+
+	// Create a placeholder variable for the converted semver.
+	var ver semver.Version
+	// Create a placeholder variable for the error.
+	var versionErr error
+
+	// Store the version value for conciseness.
+	value := aux.SchemaVersion
+
+	// Try to cast the value from interface{} to certain types.
+	switch v := value.(type) {
+	// For float types, which are the old types, we need to upcast it to semver if it's an older version.
+	case float32, float64:
+		switch v {
+		// Schema Version started being documented with "2.0".
+		// We should be able to parse it for backwards compatibility.
+		// All future versioning should be in semver format already.
+		case 2.0:
+			ver = semver.MustParse("2.0.0")
+		// If not the older version, it needs to be in semver format, send an error.
+		default:
+			return BaseComponentParseError{fmt.Sprintf("Version %v is not in semver format", v)}
+
+		}
+	// The interface type will default to string if not numeric which is what all semver types will be initially.
+	case string:
+		ver, versionErr = semver.Parse(v)
+		if versionErr != nil {
+			return BaseComponentParseError{constants.ErrMissingVersion}
+		}
+	// In the case, it's just missing completely.
+	default:
+		return BaseComponentParseError{constants.ErrMissingVersion}
+	}
+	// Copy everything from the Alias back to the original component.
+	*b = (Base)(aux.Alias)
+
+	// Get the version
+	b.SchemaVersion = ver
+	return err
 }

--- a/models/components/versions/parse.go
+++ b/models/components/versions/parse.go
@@ -4,24 +4,32 @@ import (
 	"github.com/opencontrol/compliance-masonry/models/components/versions/base"
 	"gopkg.in/yaml.v2"
 	v2 "github.com/opencontrol/compliance-masonry/models/components/versions/2_0_0"
-	"github.com/opencontrol/compliance-masonry/tools/constants"
 	"github.com/opencontrol/compliance-masonry/config"
 	"fmt"
+	"github.com/blang/semver"
+	"github.com/opencontrol/compliance-masonry/tools/constants"
+	"errors"
 )
 
-const (
-	ComponentV2_0 = 2.0
+var (
+	ComponentV2_0_0 = semver.MustParse("2.0.0")
 )
 
 func ParseComponent(componentData []byte) (base.Component, error) {
 	b := base.Base{}
 	err := yaml.Unmarshal(componentData, &b)
 	if err != nil {
-		return nil, constants.ErrMissingVersion
+		// If we have a human friendly BaseComponentParseError, return it.
+		switch err.(type) {
+		case base.BaseComponentParseError:
+			return nil, err
+		}
+		// Otherwise, just return a generic error about the schema.
+		return nil, errors.New(constants.ErrComponentSchema)
 	}
 	var component base.Component
-	switch b.SchemaVersion {
-	case ComponentV2_0:
+	switch {
+	case ComponentV2_0_0.EQ(b.SchemaVersion):
 		c := new(v2.Component)
 		err = yaml.Unmarshal(componentData, c)
 		component = c
@@ -30,7 +38,10 @@ func ParseComponent(componentData []byte) (base.Component, error) {
 
 	}
 	if err != nil {
-		return nil, fmt.Errorf(constants.ErrComponentSchemaParsef, b.SchemaVersion)
+		return nil, fmt.Errorf("Unable to parse component. Please check component.yaml schema for version %s", b.SchemaVersion.String())
 	}
+	// Copy version from base because some versions of the component can not expect to parse directly into it's own struct
+	// e.g. version 2.0.0 with 2.0 float
+	component.SetVersion(b.SchemaVersion)
 	return component, nil
 }

--- a/models/opencontrol.go
+++ b/models/opencontrol.go
@@ -121,7 +121,7 @@ func (openControl *OpenControl) LoadComponent(componentDir string) error {
 	// Read the component file.
 	componentData, err := fs.OpenAndReadFile(filepath.Join(componentDir, "component.yaml"))
 	if err != nil {
-		return constants.ErrComponentFileDNE
+		return errors.New(constants.ErrComponentFileDNE)
 	}
 	// Parse the component.
 	var component base.Component

--- a/tools/constants/constants.go
+++ b/tools/constants/constants.go
@@ -1,7 +1,5 @@
 package constants
 
-import "errors"
-
 const (
 	// DefaultStandardsFolder is the folder where to store standards.
 	DefaultStandardsFolder = "standards"
@@ -28,15 +26,10 @@ const (
 )
 
 const (
-	// ErrComponentSchemaParsef is a formatted string for reporting which version schema to check.
-	ErrComponentSchemaParsef = "Unable to parse component. Please check component.yaml schema for version %v"
-)
-
-var (
 	// ErrMissingVersion reports that the schema version cannot be found.
-	ErrMissingVersion            = errors.New("Schema Version can not be found.")
+	ErrMissingVersion  = "Schema Version can not be found."
 	// ErrComponentFileDNE is raised when a component file does not exists
-	ErrComponentFileDNE = errors.New("Component files does not exist")
+	ErrComponentFileDNE = "Component files does not exist"
 	// ErrControlSchema is raised a control cannot be parsed
-	ErrComponentSchema = errors.New("Unable to parse component")
+	ErrComponentSchema = "Unable to parse component"
 )


### PR DESCRIPTION
Also adds tests cases for non 2.0.
This patch allows someone to use float for only version 2.0 (for backwards compatibility). Otherwise it will error.