### PR TITLE
V3 0 0 cli errors

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -36,9 +36,9 @@ func diffCommandAction(c *cli.Context) error {
 		Certification:  c.Args().First(),
 		OpencontrolDir: opencontrolDir,
 	}
-	inventory, err := inventory.ComputeGapAnalysis(config)
-	if err != nil && len(err.Error()) > 0 {
-		return cli.NewExitError(err.Error(), 1)
+	inventory, errs := inventory.ComputeGapAnalysis(config)
+	if errs != nil && len(errs) > 0 {
+		return cli.NewExitError(cli.NewMultiError(errs...).Error(), 1)
 	}
 
 	c.App.Writer.Write([]byte(fmt.Sprintf("\nNumber of missing controls: %d\n", len(inventory.MissingControlList))))

--- a/diff.go
+++ b/diff.go
@@ -5,7 +5,6 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/opencontrol/compliance-masonry/inventory"
 	"github.com/tg/gosortmap"
-	"strings"
 )
 
 const (
@@ -38,8 +37,8 @@ func diffCommandAction(c *cli.Context) error {
 		OpencontrolDir: opencontrolDir,
 	}
 	inventory, err := inventory.ComputeGapAnalysis(config)
-	if err != nil && len(err) > 0 {
-		return cli.NewExitError(strings.Join(err, "\n"), 1)
+	if err != nil && len(err.Error()) > 0 {
+		return cli.NewExitError(err.Error(), 1)
 	}
 
 	c.App.Writer.Write([]byte(fmt.Sprintf("\nNumber of missing controls: %d\n", len(inventory.MissingControlList))))

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6,37 +6,40 @@ import (
 	"github.com/opencontrol/compliance-masonry/docx"
 	"github.com/opencontrol/compliance-masonry/gitbook"
 	"github.com/opencontrol/compliance-masonry/tools/certifications"
+	"errors"
 )
 
-func BuildTemplate(config docx.Config) []string {
-	var messages []string
+func BuildTemplate(config docx.Config) error {
 	if config.TemplatePath == "" {
-		messages = append(messages, "Error: No Template Supplied")
-		return messages
+		return errors.New("Error: No Template Supplied")
 	}
 	if _, err := os.Stat(config.TemplatePath); os.IsNotExist(err) {
-		messages = append(messages, "Error: Template does not exist")
-		return messages
+		return errors.New("Error: Template does not exist")
 	}
 	err := config.BuildDocx()
 	if err != nil {
-		messages = append(messages, err.Error())
-	} else {
-		messages = append(messages, "New Docx Created")
+		return err
 	}
-	return messages
+	return nil
 }
 
-func MakeGitbook(config gitbook.Config) []string {
-	certificationPath, messages := certifications.GetCertification(config.OpencontrolDir, config.Certification)
+func MakeGitbook(config gitbook.Config) ([]error) {
+	var errs []error
+	certificationPath, err := certifications.GetCertification(config.OpencontrolDir, config.Certification)
 	if certificationPath == "" {
-		return messages
+		return append(errs, err)
 	}
+	//errMessages := cli.NewMultiError()
 	if _, err := os.Stat(config.MarkdownPath); os.IsNotExist(err) {
-		messages = append(messages, "Warning: markdown directory does not exist")
+		errs = append(errs, errors.New("Warning: markdown directory does not exist"))
+		//errMessages.Errors = append(errMessages.Errors, errors.New("Warning: markdown directory does not exist"))
 	}
 	config.Certification = certificationPath
-	config.BuildGitbook()
-	messages = append(messages, "New Gitbook Documentation Created")
-	return messages
+	if err := config.BuildGitbook(); err != nil {
+		//panic(err.Error())
+		return append(errs, err...)
+		///errMessages.Errors = append(errMessages.Errors, err)
+		//panic(errMessages.Error())
+	}
+	return nil
 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -23,23 +23,18 @@ func BuildTemplate(config docx.Config) error {
 	return nil
 }
 
-func MakeGitbook(config gitbook.Config) ([]error) {
-	var errs []error
+func MakeGitbook(config gitbook.Config) (string, []error) {
+	warning := ""
 	certificationPath, err := certifications.GetCertification(config.OpencontrolDir, config.Certification)
 	if certificationPath == "" {
-		return append(errs, err)
+		return warning, err
 	}
-	//errMessages := cli.NewMultiError()
 	if _, err := os.Stat(config.MarkdownPath); os.IsNotExist(err) {
-		errs = append(errs, errors.New("Warning: markdown directory does not exist"))
-		//errMessages.Errors = append(errMessages.Errors, errors.New("Warning: markdown directory does not exist"))
+		warning = "Warning: markdown directory does not exist"
 	}
 	config.Certification = certificationPath
 	if err := config.BuildGitbook(); err != nil {
-		//panic(err.Error())
-		return append(errs, err...)
-		///errMessages.Errors = append(errMessages.Errors, err)
-		//panic(errMessages.Error())
+		return warning, err
 	}
-	return nil
+	return warning, nil
 }

--- a/docx/docx.go
+++ b/docx/docx.go
@@ -26,7 +26,8 @@ type OpenControlDocx struct {
 
 //BuildDocx exports a Docx ssp based on a template
 func (config *Config) BuildDocx() error {
-	openControl := OpenControlDocx{models.LoadData(config.OpencontrolDir, "")}
+	openControlData, _ := models.LoadData(config.OpencontrolDir, "")
+	openControl := OpenControlDocx{openControlData}
 	docTemplate, err := docTemp.GetTemplate(config.TemplatePath)
 	if err != nil {
 		return err

--- a/docx/docx_test.go
+++ b/docx/docx_test.go
@@ -20,10 +20,12 @@ import (
 var _ = Describe("Docx", func() {
 
 	DescribeTable("FormatAllNarratives", func(standard string, control string, expectedData string,) {
+		openControlData, err := models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), "")
 		openControl := OpenControlDocx{
-			OpenControl: models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), ""),
+			OpenControl: openControlData,
 		}
 		actualData := openControl.FormatAllNarratives(standard, control)
+		assert.Nil(GinkgoT(), err)
 		assert.Equal(GinkgoT(), expectedData, actualData)
 	},
 		// Get All Control Data
@@ -33,10 +35,12 @@ var _ = Describe("Docx", func() {
 	)
 
 	DescribeTable("FormatNarrative", func(standard string, control string, expectedData string, sectionKeys ...string) {
+		openControlData, err := models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), "")
 		openControl := OpenControlDocx{
-			OpenControl: models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), ""),
+			OpenControl: openControlData,
 		}
 		actualData := openControl.FormatNarrative(standard, control, sectionKeys...)
+		assert.Nil(GinkgoT(), err)
 		assert.Equal(GinkgoT(), expectedData, actualData)
 	},
 		// Get Specific Control Data
@@ -50,10 +54,12 @@ var _ = Describe("Docx", func() {
 	)
 
 	DescribeTable("FormatParameter", func(standard string, control string, expectedData string, sectionKeys ...string) {
+		openControlData, err := models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), "")
 		openControl := OpenControlDocx{
-			OpenControl: models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), ""),
+			OpenControl: openControlData,
 		}
 		actualData := openControl.FormatParameter(standard, control, sectionKeys...)
+		assert.Nil(GinkgoT(), err)
 		assert.Equal(GinkgoT(), expectedData, actualData)
 	},
 		Entry("openControl.FormatParameter(NIST-800-53@CM-2) - Not specifying a parameter should say no available info", "NIST-800-53", "CM-2", "Amazon Elastic Compute Cloud\nNo information available for component\n"),
@@ -65,10 +71,12 @@ var _ = Describe("Docx", func() {
 	)
 
 	DescribeTable("FormatResponsibleRole", func(standard string, control string, expectedData string, sectionKeys ...string) {
+		openControlData, err := models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), "")
 		openControl := OpenControlDocx{
-			OpenControl: models.LoadData(filepath.Join("..", "fixtures", "opencontrol_fixtures"), ""),
+			OpenControl: openControlData,
 		}
 		actualData := openControl.FormatResponsibleRoles(standard, control)
+		assert.Nil(GinkgoT(), err)
 		assert.Equal(GinkgoT(), expectedData, actualData)
 	},
 		Entry("openControl.FormatResponsibleRole(NIST-800-53@CM-2) - Regular case", "NIST-800-53", "CM-2", "Amazon Elastic Compute Cloud: AWS Staff\n"),

--- a/gitbook/gitbook.go
+++ b/gitbook/gitbook.go
@@ -52,9 +52,14 @@ func replaceParentheses(text string) string {
 }
 
 // BuildGitbook entry point for creating gitbook
-func (config Config) BuildGitbook() {
+func (config Config) BuildGitbook() []error {
+	var errs []error
+	openControlData, err := models.LoadData(config.OpencontrolDir, config.Certification)
+	if err != nil && len(err) > 0 {
+		return append(errs, err...)
+	}
 	openControl := OpenControlGitBook{
-		models.LoadData(config.OpencontrolDir, config.Certification),
+		openControlData,
 		config.MarkdownPath,
 		config.ExportPath,
 		fs.OSUtil{},
@@ -62,7 +67,10 @@ func (config Config) BuildGitbook() {
 	openControl.FSUtil.Mkdirs(config.ExportPath)
 	openControl.FSUtil.Mkdirs(filepath.Join(config.ExportPath, "components"))
 	openControl.FSUtil.Mkdirs(filepath.Join(config.ExportPath, "standards"))
-	openControl.buildSummaries()
+	if err := openControl.buildSummaries(); err != nil {
+		return append(errs, err)
+	}
 	openControl.exportComponents()
 	openControl.exportStandards()
+	return nil
 }

--- a/gitbook/gitbookCertification_test.go
+++ b/gitbook/gitbookCertification_test.go
@@ -54,8 +54,12 @@ func TestExportControl(t *testing.T) {
 			log.Fatal(err)
 		}
 		defer os.RemoveAll(dir)
+		openControlData, errs := models.LoadData(example.opencontrolDir, example.certificationPath)
+		if len(errs) > 0 {
+			log.Fatal("Should have loaded the opencontrol data.")
+		}
 		openControl := OpenControlGitBook{
-			models.LoadData(example.opencontrolDir, example.certificationPath),
+			openControlData,
 			"",
 			dir,
 			fs.OSUtil{},

--- a/gitbook/gitbookSummaries.go
+++ b/gitbook/gitbookSummaries.go
@@ -53,12 +53,17 @@ func (openControl *OpenControlGitBook) buildMarkdowns() {
 }
 
 // buildSummaries creates the general summary
-func (openControl *OpenControlGitBook) buildSummaries() {
+func (openControl *OpenControlGitBook) buildSummaries() error {
 	openControl.buildMarkdowns()
 	standardsSummary, familySummaryMap := openControl.buildStandardsSummaries()
 	componentsSummary := openControl.buildComponentsSummaries()
 	openControl.exportFamilyReadMap(familySummaryMap)
 	summary := standardsSummary + componentsSummary
-	go openControl.FSUtil.AppendOrCreate(filepath.Join(openControl.exportPath, "SUMMARY.md"), summary)
-	go openControl.FSUtil.AppendOrCreate(filepath.Join(openControl.exportPath, "README.md"), summary)
+	if err := openControl.FSUtil.AppendOrCreate(filepath.Join(openControl.exportPath, "SUMMARY.md"), summary); err != nil {
+		return err
+	}
+	if err := openControl.FSUtil.AppendOrCreate(filepath.Join(openControl.exportPath, "README.md"), summary); err != nil {
+		return err
+	}
+	return nil
 }

--- a/gitbook/gitbookSummaries_test.go
+++ b/gitbook/gitbookSummaries_test.go
@@ -38,8 +38,9 @@ var buildComponentsSummariesTests = []buildComponentsSummariesTest{
 
 func TestBuildComponentsSummaries(t *testing.T) {
 	for _, example := range buildComponentsSummariesTests {
+		openControlData, _ := models.LoadData(example.opencontrolDir, example.certificationPath)
 		openControl := OpenControlGitBook{
-			models.LoadData(example.opencontrolDir, example.certificationPath),
+			openControlData,
 			"",
 			example.exportPath,
 			fs.OSUtil{},
@@ -70,8 +71,9 @@ var buildStandardsSummariesTests = []buildStandardsSummariesTest{
 
 func TestBuildStandardsSummaries(t *testing.T) {
 	for _, example := range buildStandardsSummariesTests {
+		openControlData, _ := models.LoadData(example.opencontrolDir, example.certificationPath)
 		openControl := OpenControlGitBook{
-			models.LoadData(example.opencontrolDir, example.certificationPath),
+			openControlData,
 			"",
 			example.exportPath,
 			fs.OSUtil{},

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -64,11 +64,11 @@ type Config struct {
 // opencontrol workspace if successful. Otherwise, it will return a list of error messages.
 // TODO: fix the error return to return of type error. This was used because existing code returned that type
 // TODO: e.g. GetCertification
-func ComputeGapAnalysis(config Config) (Inventory, error) {
+func ComputeGapAnalysis(config Config) (Inventory, []error) {
 	// Initialize inventory with certification
-	certificationPath, messages := certifications.GetCertification(config.OpencontrolDir, config.Certification)
+	certificationPath, errs := certifications.GetCertification(config.OpencontrolDir, config.Certification)
 	if certificationPath == "" {
-		return Inventory{}, messages
+		return Inventory{}, errs
 	}
 	openControlData, _ := models.LoadData(config.OpencontrolDir, certificationPath)
 	i := Inventory{
@@ -78,7 +78,7 @@ func ComputeGapAnalysis(config Config) (Inventory, error) {
 		MissingControlList:      make(map[string]models.Control),
 	}
 	if i.Certification == nil || i.Components == nil {
-		return Inventory{}, fmt.Errorf("Unable to load data in %s for certification %s", config.OpencontrolDir, config.Certification)
+		return Inventory{}, []error{fmt.Errorf("Unable to load data in %s for certification %s", config.OpencontrolDir, config.Certification)}
 	}
 
 	// Gather list of all controls for certification

--- a/inventory/inventory_test.go
+++ b/inventory/inventory_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
+	"errors"
 )
 
 var _ = Describe("Inventory", func() {
@@ -22,7 +23,7 @@ var _ = Describe("Inventory", func() {
 				It("should return an empty slice and an error", func() {
 					config := Config{}
 					i, err := ComputeGapAnalysis(config)
-					assert.Equal(GinkgoT(), []string{"Error: Missing Certification Argument"}, err)
+					assert.Equal(GinkgoT(), []error{errors.New("Error: Missing Certification Argument")}, err)
 					assert.Equal(GinkgoT(), 0, len(i.MissingControlList))
 				})
 			})
@@ -30,7 +31,7 @@ var _ = Describe("Inventory", func() {
 				It("should return an empty slice and an error", func() {
 					config := Config{Certification: "LATO"}
 					i, err := ComputeGapAnalysis(config)
-					assert.Equal(GinkgoT(), []string{"Error: `certifications` directory does exist"}, err)
+					assert.Equal(GinkgoT(), []error{errors.New("Error: `certifications` directory does exist")}, err)
 					assert.Equal(GinkgoT(), 0, len(i.MissingControlList))
 				})
 			})

--- a/masonry-go.go
+++ b/masonry-go.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/opencontrol/compliance-masonry/config/common"
@@ -118,9 +117,15 @@ func NewCLIApp() *cli.App {
 							ExportPath:     exportPath,
 							MarkdownPath:   markdownPath,
 						}
-						messages := docs.MakeGitbook(config)
-						app.Writer.Write([]byte(strings.Join(messages, "\n")))
-						return nil
+						errMessages := docs.MakeGitbook(config)
+						if errMessages != nil && len(errMessages) > 0{
+							err := cli.NewMultiError(errMessages...)
+							app.Writer.Write([]byte(err.Error()))
+							return cli.NewExitError(err.Error(), 1)
+						} else {
+							app.Writer.Write([]byte("New Gitbook Documentation Created"))
+							return nil
+						}
 					},
 				},
 				{
@@ -153,9 +158,13 @@ func NewCLIApp() *cli.App {
 							TemplatePath:   templatePath,
 							ExportPath:     exportPath,
 						}
-						messages := docs.BuildTemplate(config)
-						app.Writer.Write([]byte(strings.Join(messages, "\n")))
-						return nil
+						if err := docs.BuildTemplate(config); err != nil && len(err.Error()) > 0 {
+							app.Writer.Write([]byte(err.Error()))
+							return cli.NewExitError(err.Error(), 1)
+						} else {
+							app.Writer.Write([]byte("New Docx Created"))
+							return nil
+						}
 					},
 				},
 			},

--- a/masonry-go.go
+++ b/masonry-go.go
@@ -117,7 +117,10 @@ func NewCLIApp() *cli.App {
 							ExportPath:     exportPath,
 							MarkdownPath:   markdownPath,
 						}
-						errMessages := docs.MakeGitbook(config)
+						warning, errMessages := docs.MakeGitbook(config)
+						if warning != "" {
+							app.Writer.Write([]byte(warning))
+						}
 						if errMessages != nil && len(errMessages) > 0{
 							err := cli.NewMultiError(errMessages...)
 							app.Writer.Write([]byte(err.Error()))

--- a/masonry-go.go
+++ b/masonry-go.go
@@ -123,7 +123,6 @@ func NewCLIApp() *cli.App {
 						}
 						if errMessages != nil && len(errMessages) > 0{
 							err := cli.NewMultiError(errMessages...)
-							app.Writer.Write([]byte(err.Error()))
 							return cli.NewExitError(err.Error(), 1)
 						} else {
 							app.Writer.Write([]byte("New Gitbook Documentation Created"))
@@ -162,7 +161,6 @@ func NewCLIApp() *cli.App {
 							ExportPath:     exportPath,
 						}
 						if err := docs.BuildTemplate(config); err != nil && len(err.Error()) > 0 {
-							app.Writer.Write([]byte(err.Error()))
 							return cli.NewExitError(err.Error(), 1)
 						} else {
 							app.Writer.Write([]byte("New Docx Created"))

--- a/masonry-go.go
+++ b/masonry-go.go
@@ -58,7 +58,7 @@ func NewCLIApp() *cli.App {
 					Usage: "Location of system yaml",
 				},
 			},
-			Action: func(c *cli.Context) {
+			Action: func(c *cli.Context) error {
 				f := fs.OSUtil{}
 				config := c.String("config")
 				configBytes, err := f.OpenAndReadFile(config)
@@ -76,10 +76,10 @@ func NewCLIApp() *cli.App {
 					configBytes,
 					&common.ConfigWorker{Downloader: common.NewVCSDownloader(), Parser: parser.Parser{}, ResourceMap: mapset.Init(), FSUtil: f})
 				if err != nil {
-					app.Writer.Write([]byte(err.Error()))
-					os.Exit(1)
+					return cli.NewExitError(err.Error(), 1)
 				}
 				app.Writer.Write([]byte("Compliance Dependencies Installed"))
+				return nil
 			},
 		},
 		{
@@ -111,7 +111,7 @@ func NewCLIApp() *cli.App {
 							Destination: &markdownPath,
 						},
 					},
-					Action: func(c *cli.Context) {
+					Action: func(c *cli.Context) error {
 						config := gitbook.Config{
 							Certification:  c.Args().First(),
 							OpencontrolDir: opencontrolDir,
@@ -120,6 +120,7 @@ func NewCLIApp() *cli.App {
 						}
 						messages := docs.MakeGitbook(config)
 						app.Writer.Write([]byte(strings.Join(messages, "\n")))
+						return nil
 					},
 				},
 				{
@@ -146,7 +147,7 @@ func NewCLIApp() *cli.App {
 							Destination: &exportPath,
 						},
 					},
-					Action: func(c *cli.Context) {
+					Action: func(c *cli.Context) error {
 						config := docx.Config{
 							OpencontrolDir: opencontrolDir,
 							TemplatePath:   templatePath,
@@ -154,6 +155,7 @@ func NewCLIApp() *cli.App {
 						}
 						messages := docs.BuildTemplate(config)
 						app.Writer.Write([]byte(strings.Join(messages, "\n")))
+						return nil
 					},
 				},
 			},

--- a/masonry-go_test.go
+++ b/masonry-go_test.go
@@ -44,14 +44,14 @@ var _ = Describe("Masonry CLI", func() {
 			Describe("When the CLI is run with the `docs gitbook` command", func() {
 				It("should let the user know that they have not described a certification and show how to use the command", func() {
 					output := Masonry("docs", "gitbook")
-					Eventually(output.Out.Contents).Should(ContainSubstring("Error: Missing Certification Argument"))
+					Eventually(output.Err.Contents).Should(ContainSubstring("Error: Missing Certification Argument"))
 				})
 			})
 
 			Describe("When the CLI is run with the `docs gitbook` command without opencontrols dir", func() {
 				It("should let the user know that there is no opencontrols/certifications directory", func() {
 					output := Masonry("docs", "gitbook", "LATO")
-					Eventually(output.Out.Contents).Should(ContainSubstring("Error: `" + filepath.Join("opencontrols", "certifications") + "` directory does exist"))
+					Eventually(output.Err.Contents).Should(ContainSubstring("Error: `" + filepath.Join("opencontrols", "certifications") + "` directory does exist"))
 				})
 			})
 		})
@@ -95,14 +95,14 @@ var _ = Describe("Masonry CLI", func() {
 		Describe("When the docs docx command is run", func() {
 			It("should warn the user that no template has been supplied", func() {
 				output := Masonry("docs", "docx")
-				Eventually(output.Out.Contents).Should(ContainSubstring("Error: No Template Supplied"))
+				Eventually(output.Err.Contents).Should(ContainSubstring("Error: No Template Supplied"))
 			})
 		})
 
 		Describe("When the docs docx command is run with a none existent template", func() {
 			It("should warn the user that no template does not exist", func() {
 				output := Masonry("docs", "docx", "-t", "test")
-				Eventually(output.Out.Contents).Should(ContainSubstring("Error: Template does not exist"))
+				Eventually(output.Err.Contents).Should(ContainSubstring("Error: Template does not exist"))
 			})
 		})
 
@@ -114,7 +114,7 @@ var _ = Describe("Masonry CLI", func() {
 					"-t", filepath.Join("fixtures", "template_fixtures", "test_corrupted.docx"),
 					"-e", filepath.Join(exportTempDir, "export.docx"),
 				)
-				Eventually(output.Out.Contents).Should(ContainSubstring("Cannot Open File"))
+				Eventually(output.Err.Contents).Should(ContainSubstring("Cannot Open File"))
 			})
 		})
 

--- a/models/components/versions/parse.go
+++ b/models/components/versions/parse.go
@@ -8,8 +8,6 @@ import (
 	"github.com/opencontrol/compliance-masonry/config"
 	"fmt"
 	"github.com/blang/semver"
-	"github.com/opencontrol/compliance-masonry/tools/constants"
-	"errors"
 )
 
 var (
@@ -17,7 +15,7 @@ var (
 	ComponentV3_0_0 = semver.MustParse("3.0.0")
 )
 
-func ParseComponent(componentData []byte) (base.Component, error) {
+func ParseComponent(componentData []byte, fileName string) (base.Component, error) {
 	b := base.Base{}
 	err := yaml.Unmarshal(componentData, &b)
 	if err != nil {
@@ -27,7 +25,7 @@ func ParseComponent(componentData []byte) (base.Component, error) {
 			return nil, err
 		}
 		// Otherwise, just return a generic error about the schema.
-		return nil, errors.New(constants.ErrComponentSchema)
+		return nil, fmt.Errorf("Unable to parse component %s. Error: %s", fileName, err.Error())
 	}
 	var component base.Component
 	switch {

--- a/models/components/versions/parse_test.go
+++ b/models/components/versions/parse_test.go
@@ -193,7 +193,7 @@ var componentTestErrors = []componentTestError{
 	// Check loading a component with no file
 	{"", errors.New(constants.ErrComponentFileDNE)},
 	// Check loading a component with a broken schema
-	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2BrokenControl"), errors.New("Unable to parse component ../../../fixtures/component_fixtures/common/EC2BrokenControl/component.yaml. Error: yaml: line 16: did not find expected key")},
+	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2BrokenControl"), errors.New("Unable to parse component " +filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2BrokenControl", "component.yaml") + ". Error: yaml: line 16: did not find expected key")},
 	// Check for version that is unsupported
 	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2UnsupportedVersion"), config.ErrUnknownSchemaVersion},
 	// Check for the case when someone says they are using a certain version (2.0) but it actually is not

--- a/models/components/versions/parse_test.go
+++ b/models/components/versions/parse_test.go
@@ -193,7 +193,7 @@ var componentTestErrors = []componentTestError{
 	// Check loading a component with no file
 	{"", errors.New(constants.ErrComponentFileDNE)},
 	// Check loading a component with a broken schema
-	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2BrokenControl"), errors.New(constants.ErrComponentSchema)},
+	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2BrokenControl"), errors.New("Unable to parse component ../../../fixtures/component_fixtures/common/EC2BrokenControl/component.yaml. Error: yaml: line 16: did not find expected key")},
 	// Check for version that is unsupported
 	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2UnsupportedVersion"), config.ErrUnknownSchemaVersion},
 	// Check for the case when someone says they are using a certain version (2.0) but it actually is not

--- a/models/opencontrol.go
+++ b/models/opencontrol.go
@@ -145,7 +145,6 @@ func (openControl *OpenControl) LoadComponent(componentDir string) error {
 	if component.GetKey() == "" {
 		component.SetKey(getKey(componentDir))
 	}
-	fmt.Printf("Loaded component (%s) key\n", component.GetKey())
 	// If the component is new, make sure we load the justifications as well.
 	if openControl.Components.CompareAndAdd(component) {
 		openControl.Justifications.LoadMappings(component)

--- a/models/opencontrol.go
+++ b/models/opencontrol.go
@@ -11,6 +11,8 @@ import (
 	"github.com/opencontrol/compliance-masonry/models/components"
 	"github.com/opencontrol/compliance-masonry/tools/constants"
 	"github.com/opencontrol/compliance-masonry/tools/fs"
+	"fmt"
+	"github.com/codegangsta/cli"
 )
 
 var (
@@ -50,66 +52,75 @@ func NewOpenControl() *OpenControl {
 
 // LoadData creates a new instance of OpenControl struct and loads
 // the components, standards, and certification data.
-func LoadData(openControlDir string, certificationPath string) *OpenControl {
+func LoadData(openControlDir string, certificationPath string) (*OpenControl, []error) {
 	var wg sync.WaitGroup
 	openControl := NewOpenControl()
 	wg.Add(3)
-	go func() {
+	var componentsErrs, standardsErrs []error
+	var certificationErr error
+	go func(wg *sync.WaitGroup) {
 		defer wg.Done()
-		openControl.LoadComponents(filepath.Join(openControlDir, "components"))
-	}()
-	go func() {
+		componentsErrs = openControl.LoadComponents(filepath.Join(openControlDir, "components"))
+	}(&wg)
+	go func(wg *sync.WaitGroup) {
 		defer wg.Done()
-		openControl.LoadStandards(filepath.Join(openControlDir, "standards"))
-	}()
-	go func() {
+		standardsErrs = openControl.LoadStandards(filepath.Join(openControlDir, "standards"))
+	}(&wg)
+	go func(wg *sync.WaitGroup) {
 		defer wg.Done()
-		openControl.LoadCertification(certificationPath)
-	}()
+		certificationErr = openControl.LoadCertification(certificationPath)
+	}(&wg)
 	wg.Wait()
-	return openControl
+	var errs []error
+	//errs = append(errs, certificationErr)
+	errs = append(errs, componentsErrs...)
+	errs = append(errs, standardsErrs...)
+	return openControl, errs
 }
 
 // LoadComponents loads multiple components by searching for components in a
 // given directory
-func (openControl *OpenControl) LoadComponents(directory string) error {
+func (openControl *OpenControl) LoadComponents(directory string) []error {
 	var wg sync.WaitGroup
 	componentsDir, err := ioutil.ReadDir(directory)
 	if err != nil {
-		return ErrReadDir
+		return []error{ErrReadDir}
 	}
+	errChannel := make(chan error ,len(componentsDir))
+	wg.Add(len(componentsDir))
 	for _, componentDir := range componentsDir {
-		wg.Add(1)
-		go func(componentDir os.FileInfo) {
+		go func(componentDir os.FileInfo, wg *sync.WaitGroup) {
 			if componentDir.IsDir() {
 				componentDir := filepath.Join(directory, componentDir.Name())
-				openControl.LoadComponent(componentDir)
+				errChannel <- openControl.LoadComponent(componentDir)
 			}
 			wg.Done()
-		}(componentDir)
+		}(componentDir, &wg)
 	}
 	wg.Wait()
-	return nil
+	close(errChannel)
+	return convertErrChannelToError(errChannel)
 }
 
 // LoadStandards loads multiple standards by searching for components in a
 // given directory
-func (openControl *OpenControl) LoadStandards(standardsDir string) error {
+func (openControl *OpenControl) LoadStandards(standardsDir string) []error {
 	var wg sync.WaitGroup
-
 	standardsFiles, err := ioutil.ReadDir(standardsDir)
 	if err != nil {
-		return ErrReadDir
+		return []error{ErrReadDir}
 	}
+	errChannel := make(chan error, len(standardsFiles))
+	wg.Add(len(standardsFiles))
 	for _, standardFile := range standardsFiles {
-		wg.Add(1)
-		go func(standardFile os.FileInfo) {
-			openControl.LoadStandard(filepath.Join(standardsDir, standardFile.Name()))
+		go func(standardFile os.FileInfo, wg *sync.WaitGroup) {
+			errChannel <- openControl.LoadStandard(filepath.Join(standardsDir, standardFile.Name()))
 			wg.Done()
-		}(standardFile)
+		}(standardFile, &wg)
 	}
 	wg.Wait()
-	return nil
+	close(errChannel)
+	return convertErrChannelToError(errChannel)
 }
 
 
@@ -119,13 +130,14 @@ func (openControl *OpenControl) LoadComponent(componentDir string) error {
 	// Get file system assistance.
 	fs := fs.OSUtil{}
 	// Read the component file.
-	componentData, err := fs.OpenAndReadFile(filepath.Join(componentDir, "component.yaml"))
+	fileName := filepath.Join(componentDir, "component.yaml")
+	componentData, err := fs.OpenAndReadFile(fileName)
 	if err != nil {
 		return errors.New(constants.ErrComponentFileDNE)
 	}
 	// Parse the component.
 	var component base.Component
-	component, err = versions.ParseComponent(componentData)
+	component, err = versions.ParseComponent(componentData,fileName)
 	if err != nil {
 		return err
 	}
@@ -133,9 +145,20 @@ func (openControl *OpenControl) LoadComponent(componentDir string) error {
 	if component.GetKey() == "" {
 		component.SetKey(getKey(componentDir))
 	}
+	fmt.Printf("Loaded component (%s) key\n", component.GetKey())
 	// If the component is new, make sure we load the justifications as well.
 	if openControl.Components.CompareAndAdd(component) {
 		openControl.Justifications.LoadMappings(component)
 	}
 	return nil
+}
+
+func convertErrChannelToError(errs <-chan error) []error {
+	errMessages := cli.NewMultiError()
+	for err := range errs {
+		if err != nil && len(err.Error()) > 0 {
+			errMessages.Errors = append(errMessages.Errors, err)
+		}
+	}
+	return errMessages.Errors
 }

--- a/models/opencontrol.go
+++ b/models/opencontrol.go
@@ -99,7 +99,7 @@ func (openControl *OpenControl) LoadComponents(directory string) []error {
 	}
 	wg.Wait()
 	close(errChannel)
-	return convertErrChannelToError(errChannel)
+	return convertErrChannelToErrorSlice(errChannel)
 }
 
 // LoadStandards loads multiple standards by searching for components in a
@@ -120,7 +120,7 @@ func (openControl *OpenControl) LoadStandards(standardsDir string) []error {
 	}
 	wg.Wait()
 	close(errChannel)
-	return convertErrChannelToError(errChannel)
+	return convertErrChannelToErrorSlice(errChannel)
 }
 
 
@@ -153,7 +153,7 @@ func (openControl *OpenControl) LoadComponent(componentDir string) error {
 	return nil
 }
 
-func convertErrChannelToError(errs <-chan error) []error {
+func convertErrChannelToErrorSlice(errs <-chan error) []error {
 	errMessages := cli.NewMultiError()
 	for err := range errs {
 		if err != nil && len(err.Error()) > 0 {

--- a/models/opencontrol.go
+++ b/models/opencontrol.go
@@ -11,7 +11,6 @@ import (
 	"github.com/opencontrol/compliance-masonry/models/components"
 	"github.com/opencontrol/compliance-masonry/tools/constants"
 	"github.com/opencontrol/compliance-masonry/tools/fs"
-	"fmt"
 	"github.com/codegangsta/cli"
 )
 

--- a/models/opencontrol_test.go
+++ b/models/opencontrol_test.go
@@ -55,7 +55,7 @@ var loadDataTests = []loadDataTest{
 
 func TestLoadData(t *testing.T) {
 	for _, example := range loadDataTests {
-		actual := LoadData(example.openControlDir, example.certificationPath)
+		actual, _ := LoadData(example.openControlDir, example.certificationPath)
 		actualComponentNum := len(actual.Components.GetAll())
 		// Check the number of components
 		if actualComponentNum != example.expectedComponents {

--- a/tools/certifications/certifications.go
+++ b/tools/certifications/certifications.go
@@ -1,35 +1,33 @@
 package certifications
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
-	"github.com/codegangsta/cli"
-	"github.com/vektra/errors"
 )
 
-func GetCertification(opencontrolDir string, certification string) (string, error) {
+func GetCertification(opencontrolDir string, certification string) (string, []error) {
 	certificationPath := ""
-	errMessages := cli.NewMultiError()
+	var errMessages []error
 	if certification == "" {
-		return "", errors.New("Error: Missing Certification Argument")
+		return "", []error{errors.New("Error: Missing Certification Argument")}
 	}
 	certificationDir := filepath.Join(opencontrolDir, "certifications")
 	certificationPath = filepath.Join(certificationDir, certification+".yaml")
 	if _, err := os.Stat(certificationPath); os.IsNotExist(err) {
 		files, err := ioutil.ReadDir(certificationDir)
 		if err != nil {
-			errMessages.Errors = append(errMessages.Errors, errors.New("Error: `"+certificationDir+"` directory does exist"))
-			return "", errMessages
+			return "", []error{errors.New("Error: `"+certificationDir+"` directory does exist")}
 		}
 		errMessage := fmt.Sprintf("Error: `%s` does not exist\nUse one of the following:", certificationPath)
 		for _, file := range files {
 			fileName := strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))
-			errMessage = fmt.Sprintf("%s\n`%s`", errMessages, fileName)
+			errMessage = fmt.Sprintf("%s\n%s", errMessage, fileName)
 		}
-		errMessages.Errors = append(errMessages.Errors, errors.New(errMessage))
+		errMessages = append(errMessages, errors.New(errMessage))
 		return "", errMessages
 	}
 	return certificationPath, errMessages

--- a/tools/certifications/certifications.go
+++ b/tools/certifications/certifications.go
@@ -6,31 +6,31 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"github.com/codegangsta/cli"
+	"github.com/vektra/errors"
 )
 
-func GetCertification(opencontrolDir string, certification string) (string, []string) {
-	var (
-		certificationPath string
-		messages          []string
-	)
+func GetCertification(opencontrolDir string, certification string) (string, error) {
+	certificationPath := ""
+	errMessages := cli.NewMultiError()
 	if certification == "" {
-		messages = append(messages, "Error: Missing Certification Argument")
-		return "", messages
+		return "", errors.New("Error: Missing Certification Argument")
 	}
 	certificationDir := filepath.Join(opencontrolDir, "certifications")
 	certificationPath = filepath.Join(certificationDir, certification+".yaml")
 	if _, err := os.Stat(certificationPath); os.IsNotExist(err) {
 		files, err := ioutil.ReadDir(certificationDir)
 		if err != nil {
-			messages = append(messages, "Error: `"+certificationDir+"` directory does exist")
-			return "", messages
+			errMessages.Errors = append(errMessages.Errors, errors.New("Error: `"+certificationDir+"` directory does exist"))
+			return "", errMessages
 		}
-		messages = append(messages, fmt.Sprintf("Error: `%s` does not exist\nUse one of the following:", certificationPath))
+		errMessage := fmt.Sprintf("Error: `%s` does not exist\nUse one of the following:", certificationPath)
 		for _, file := range files {
 			fileName := strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))
-			messages = append(messages, fmt.Sprintf("`%s`", fileName))
+			errMessage = fmt.Sprintf("%s\n`%s`", errMessages, fileName)
 		}
-		return "", messages
+		errMessages.Errors = append(errMessages.Errors, errors.New(errMessage))
+		return "", errMessages
 	}
-	return certificationPath, messages
+	return certificationPath, errMessages
 }

--- a/tools/constants/constants.go
+++ b/tools/constants/constants.go
@@ -30,8 +30,6 @@ const (
 	ErrMissingVersion  = "Schema Version can not be found."
 	// ErrComponentFileDNE is raised when a component file does not exists
 	ErrComponentFileDNE = "Component files does not exist"
-	// ErrControlSchema is raised a control cannot be parsed
-	ErrComponentSchema = "Unable to parse component"
 )
 
 const (


### PR DESCRIPTION
This patch cleans up error handling.
It fixes #147 deprecation message.
It makes more methods return error (beforehand the methods returned nothing) 
It fixes methods that returned []string to represent both warnings and strings in one data structure, now methods will return a string for warning and []error for errors.
Instead of returning a generic schema message, it will print out the filename as well as the yaml error for easier debugging