### PR TITLE
Add control_origin to v3 and gitbook rendering of control_origin

### DIFF
--- a/fixtures/component_fixtures/v3_0_0/EC2/component.yaml
+++ b/fixtures/component_fixtures/v3_0_0/EC2/component.yaml
@@ -12,6 +12,7 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  control_origin: shared
   narrative:
     - key: "a"
       text: "Justification in narrative form A for CM-2"
@@ -25,6 +26,7 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  control_origin: inherited
   parameters:
     - key: "a"
       text: "Parameter A for 1.1"
@@ -39,6 +41,7 @@ satisfies:
 - control_key: 1.1.1
   covered_by: []
   implementation_status: partial
+  control_origin: inherited
   narrative:
     - key: "a"
       text: "Justification in narrative form A for 1.1.1"
@@ -53,6 +56,7 @@ satisfies:
 - control_key: 2.1
   covered_by: []
   implementation_status: partial
+  control_origin: inherited
   narrative:
     - text: "Justification in narrative form for 2.1"
   standard_key: PCI-DSS-MAY-2015

--- a/fixtures/component_fixtures/v3_0_0/EC2WithKey/component.yaml
+++ b/fixtures/component_fixtures/v3_0_0/EC2WithKey/component.yaml
@@ -13,6 +13,7 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  control_origin: shared
   narrative:
     - key: "a"
       text: "Justification in narrative form A for CM-2"
@@ -26,6 +27,7 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  control_origin: inherited
   parameters:
     - key: "a"
       text: "Parameter A for 1.1"
@@ -40,6 +42,7 @@ satisfies:
 - control_key: 1.1.1
   covered_by: []
   implementation_status: partial
+  control_origin: inherited
   narrative:
     - key: "a"
       text: "Justification in narrative form A for 1.1.1"
@@ -54,6 +57,7 @@ satisfies:
 - control_key: 2.1
   covered_by: []
   implementation_status: partial
+  control_origin: inherited
   narrative:
     - text: "Justification in narrative form for 2.1"
   standard_key: PCI-DSS-MAY-2015

--- a/fixtures/exports_fixtures/complete_export/standards/NIST-800-53-CM-2.md
+++ b/fixtures/exports_fixtures/complete_export/standards/NIST-800-53-CM-2.md
@@ -5,6 +5,8 @@
 
 ##### Responsible Role: AWS Staff
 
+##### Control Origin: shared
+
 ##### a
 Justification in narrative form A for CM-2
 

--- a/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-1.1.md
+++ b/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-1.1.md
@@ -13,6 +13,8 @@ Parameter A for 1.1
 ###### b
 Parameter B for 1.1
 
+##### Control Origin: inherited
+
 No narrative found for the combination of standard PCI-DSS-MAY-2015 and control 1.1
 Covered By:
 * [Amazon Elastic Compute Cloud - EC2 Verification 1](../components/EC2.md)

--- a/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-2.1.md
+++ b/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-2.1.md
@@ -4,4 +4,6 @@
 #### Amazon Elastic Compute Cloud
 
 ##### Responsible Role: AWS Staff
+
+##### Control Origin: inherited
 Justification in narrative form for 2.1

--- a/fixtures/exports_fixtures/complete_export_with_markdown/standards/NIST-800-53-CM-2.md
+++ b/fixtures/exports_fixtures/complete_export_with_markdown/standards/NIST-800-53-CM-2.md
@@ -5,6 +5,8 @@
 
 ##### Responsible Role: AWS Staff
 
+##### Control Origin: shared
+
 ##### a
 Justification in narrative form A for CM-2
 

--- a/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-1.1.md
+++ b/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-1.1.md
@@ -13,6 +13,8 @@ Parameter A for 1.1
 ###### b
 Parameter B for 1.1
 
+##### Control Origin: inherited
+
 No narrative found for the combination of standard PCI-DSS-MAY-2015 and control 1.1
 Covered By:
 * [Amazon Elastic Compute Cloud - EC2 Verification 1](../components/EC2.md)

--- a/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-2.1.md
+++ b/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-2.1.md
@@ -4,4 +4,6 @@
 #### Amazon Elastic Compute Cloud
 
 ##### Responsible Role: AWS Staff
+
+##### Control Origin: inherited
 Justification in narrative form for 2.1

--- a/fixtures/opencontrol_fixtures/components/EC2/component.yaml
+++ b/fixtures/opencontrol_fixtures/components/EC2/component.yaml
@@ -12,6 +12,7 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  control_origin: shared
   narrative:
     - key: "a"
       text: "Justification in narrative form A for CM-2"
@@ -25,6 +26,7 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  control_origin: inherited
   parameters:
     - key: "a"
       text: "Parameter A for 1.1"
@@ -34,6 +36,7 @@ satisfies:
 - control_key: 2.1
   covered_by: []
   implementation_status: partial
+  control_origin: inherited
   narrative:
     - text: "Justification in narrative form for 2.1"
   standard_key: PCI-DSS-MAY-2015

--- a/fixtures/opencontrol_fixtures_with_markdown/components/EC2/component.yaml
+++ b/fixtures/opencontrol_fixtures_with_markdown/components/EC2/component.yaml
@@ -13,6 +13,7 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  control_origin: shared
   narrative:
     - key: "a"
       text: "Justification in narrative form A for CM-2"
@@ -26,6 +27,7 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  control_origin: inherited
   parameters:
     - key: "a"
       text: "Parameter A for 1.1"
@@ -35,6 +37,7 @@ satisfies:
 - control_key: 2.1
   covered_by: []
   implementation_status: partial
+  control_origin: inherited
   narrative:
     - text: "Justification in narrative form for 2.1"
   standard_key: PCI-DSS-MAY-2015

--- a/gitbook/gitbookCertification.go
+++ b/gitbook/gitbookCertification.go
@@ -80,6 +80,12 @@ func (openControl *OpenControlGitBook) getCoveredByVerification(text string, com
 	return text
 }
 
+func (openControl *OpenControlGitBook) getControlOrigin(text string, controlOrigin string) string {
+	if controlOrigin != "" {
+		text = fmt.Sprintf("%s\n##### Control Origin: %s\n", text, controlOrigin)
+	}
+	return text
+}
 
 
 func (openControl *OpenControlGitBook) exportControl(control *ControlGitbook) (string, string) {
@@ -99,6 +105,8 @@ func (openControl *OpenControlGitBook) exportControl(control *ControlGitbook) (s
 				text = openControl.getResponsibleRole(text, component)
 
 				text = openControl.getParameters(text, justification.SatisfiesData.GetParameters())
+
+				text = openControl.getControlOrigin(text, justification.SatisfiesData.GetControlOrigin())
 
 				text = openControl.getNarratives(justification.SatisfiesData.GetNarratives(), text, control)
 			})

--- a/gitbook/gitbookCertification_test.go
+++ b/gitbook/gitbookCertification_test.go
@@ -36,6 +36,8 @@ var exportControlTests = []exportControlTest{
 
 ##### Responsible Role: AWS Staff
 
+##### Control Origin: shared
+
 ##### a
 Justification in narrative form A for CM-2
 

--- a/models/components/versions/2_0_0/component.go
+++ b/models/components/versions/2_0_0/component.go
@@ -97,6 +97,10 @@ func (s Satisfies) GetCoveredBy() common.CoveredByList {
 	return s.CoveredBy
 }
 
+func (s Satisfies) GetControlOrigin() string {
+	return ""
+}
+
 type Narrative string
 
 func (n Narrative) GetKey() string {

--- a/models/components/versions/2_0_0/component_test.go
+++ b/models/components/versions/2_0_0/component_test.go
@@ -35,6 +35,7 @@ func TestComponentGetters(t *testing.T) {
 		}
 		assert.Equal(t, satisfies.GetParameters(), testSatisfies[idx].GetParameters())
 		assert.Equal(t, satisfies.GetCoveredBy(), testSatisfies[idx].GetCoveredBy())
+		assert.Equal(t, "", satisfies.GetControlOrigin())
 	}
 }
 

--- a/models/components/versions/3_0_0/component.go
+++ b/models/components/versions/3_0_0/component.go
@@ -69,6 +69,7 @@ type Satisfies struct {
 	Narrative   []NarrativeSection        `yaml:"narrative" json:"narrative"`
 	CoveredBy   common.CoveredByList `yaml:"covered_by" json:"covered_by"`
 	Parameters      []Section          `yaml:"parameters" json:"parameters"`
+	ControlOrigin string `yaml:"control_origin" json:"control_origin"`
 }
 
 func (s Satisfies) GetControlKey() string {
@@ -99,6 +100,10 @@ func (s Satisfies) GetParameters() []base.Section {
 
 func (s Satisfies) GetCoveredBy() common.CoveredByList {
 	return s.CoveredBy
+}
+
+func (s Satisfies) GetControlOrigin() string {
+	return s.ControlOrigin
 }
 
 // NarrativeSection contains the key and text for a particular section.

--- a/models/components/versions/3_0_0/component_test.go
+++ b/models/components/versions/3_0_0/component_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestComponentGetters(t *testing.T) {
-	testSatisfies := []Satisfies{{Parameters: []Section{Section{Key:"key", Text: "text"}}, Narrative: []NarrativeSection{NarrativeSection{Key: "key", Text: "text"}, NarrativeSection{Text: "text"}}}, {}, {}, {}}
+	testSatisfies := []Satisfies{{ControlOrigin: "control_origin", Parameters: []Section{Section{Key:"key", Text: "text"}}, Narrative: []NarrativeSection{NarrativeSection{Key: "key", Text: "text"}, NarrativeSection{Text: "text"}}}, {}, {}, {}}
 	component := Component{
 		Name:          "Amazon Elastic Compute Cloud",
 		Key:           "EC2",
@@ -40,6 +40,7 @@ func TestComponentGetters(t *testing.T) {
 			assert.Equal(t, satisfies.GetParameters()[i].GetText(), parameter.GetText())
 		}
 		assert.Equal(t, satisfies.GetCoveredBy(), testSatisfies[idx].GetCoveredBy())
+		assert.Equal(t, satisfies.GetControlOrigin(), testSatisfies[idx].GetControlOrigin())
 	}
 }
 

--- a/models/components/versions/base/component.go
+++ b/models/components/versions/base/component.go
@@ -25,6 +25,7 @@ type Satisfies interface {
 	GetNarratives() []Section
 	GetParameters() []Section
 	GetCoveredBy() common.CoveredByList
+	GetControlOrigin() string
 }
 
 type Section interface {


### PR DESCRIPTION
This PR:
- Introduces the `control_origin` field
- Renders the `control_origin` field to the gitbook

This PR will **NOT** change rendering to docx because we are still debating how to handle the checkboxes.