### PR TITLE
Useful error messages for the holiday weekend

### DIFF
--- a/models/components/versions/parse.go
+++ b/models/components/versions/parse.go
@@ -42,7 +42,8 @@ func ParseComponent(componentData []byte, fileName string) (base.Component, erro
 
 	}
 	if err != nil {
-		return nil, fmt.Errorf("Unable to parse component. Please check component.yaml schema for version %s", b.SchemaVersion.String())
+		return nil, fmt.Errorf("Unable to parse component. Please check component.yaml schema for version %s\n" +
+			"\tFile: %v\n\tParse error: %v", b.SchemaVersion.String(), fileName, err)
 	}
 	// Copy version from base because some versions of the component can not expect to parse directly into it's own struct
 	// e.g. version 2.0.0 with 2.0 float

--- a/models/components/versions/parse_test.go
+++ b/models/components/versions/parse_test.go
@@ -205,7 +205,8 @@ var componentTestErrors = []componentTestError{
 	// Check for the case when someone says they are using a certain version (2.0) but it actually is not
 	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2_InvalidFieldTypeForVersion2_0"),
 		errors.New("Unable to parse component. Please check component.yaml schema for version 2.0.0" +
-			"\n\tFile: ../../../fixtures/component_fixtures/common/EC2_InvalidFieldTypeForVersion2_0/component.yaml" +
+			"\n\tFile: " +
+			filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2_InvalidFieldTypeForVersion2_0", "component.yaml") +
 			"\n\tParse error: yaml: unmarshal errors:" +
 			"\n  line 9: cannot unmarshal !!str `wrong` into common.CoveredByList")},
 

--- a/models/components/versions/parse_test.go
+++ b/models/components/versions/parse_test.go
@@ -191,15 +191,27 @@ func TestLoadComponent(t *testing.T) {
 
 var componentTestErrors = []componentTestError{
 	// Check loading a component with no file
-	{"", errors.New(constants.ErrComponentFileDNE)},
+	{"",
+		errors.New(constants.ErrComponentFileDNE)},
+
 	// Check loading a component with a broken schema
-	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2BrokenControl"), errors.New("Unable to parse component " +filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2BrokenControl", "component.yaml") + ". Error: yaml: line 16: did not find expected key")},
+	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2BrokenControl"),
+		errors.New("Unable to parse component " + filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2BrokenControl", "component.yaml") + ". Error: yaml: line 16: did not find expected key")},
+
 	// Check for version that is unsupported
-	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2UnsupportedVersion"), config.ErrUnknownSchemaVersion},
+	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2UnsupportedVersion"),
+		config.ErrUnknownSchemaVersion},
+
 	// Check for the case when someone says they are using a certain version (2.0) but it actually is not
-	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2_InvalidFieldTypeForVersion2_0"), errors.New("Unable to parse component. Please check component.yaml schema for version 2.0.0")},
+	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2_InvalidFieldTypeForVersion2_0"),
+		errors.New("Unable to parse component. Please check component.yaml schema for version 2.0.0" +
+			"\n\tFile: ../../../fixtures/component_fixtures/common/EC2_InvalidFieldTypeForVersion2_0/component.yaml" +
+			"\n\tParse error: yaml: unmarshal errors:" +
+			"\n  line 9: cannot unmarshal !!str `wrong` into common.CoveredByList")},
+
 	// Check for the case when non-2.0 version is not in semver format.
-	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2VersionNotSemver"), base.NewBaseComponentParseError("Version 1 is not in semver format")},
+	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "common", "EC2VersionNotSemver"),
+		base.NewBaseComponentParseError("Version 1 is not in semver format")},
 }
 
 func TestLoadComponentErrors(t *testing.T) {


### PR DESCRIPTION
An invalid component.yaml currently results in an error like this:
```
  Unable to parse component. Please check component.yaml schema for version 3.0.0
``` 
without providing the path or the line number (Urgh!). Now we'll get:

```
Unable to parse component. Please check component.yaml schema for version 3.0.0
	File: opencontrols/components/AU_policy/component.yaml
	Parse error: yaml: unmarshal errors:
  line 12: cannot unmarshal !!map into []component.NarrativeSection
```
with filename, line number and error. Much better!

Also tried to make test cases more readable.  `go fmt` seems okay with the way I've done linebreaks (the rest of the file needs some `fmt` help, but that's another PR)