### PR TITLE
Update Readme.md to add `go build` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Compliance Masonry is a command-line interface (CLI) that allows users to constr
     go get github.com/opencontrol/compliance-masonry
     ```
 
+1. Build the tool
+
+    ```bash
+    cd $GOPATH/src/github.com/opencontrol/compliance-masonry/
+    go build
+    ```
+    
 1. Run the CLI
 
     ```bash


### PR DESCRIPTION
At least for me, just doing `go get` did not produce the `compliance-masonry` binary mentioned in the subsequent step. This adds to the docs the build step that produces the binary.