### PR TITLE
Fix "Already exists" error when sharing single repo for standards and certifications

### DIFF
--- a/tools/mapset/map.go
+++ b/tools/mapset/map.go
@@ -38,7 +38,11 @@ func (m *MapSet) Reserve(key string, value string) (result Result) {
 		innerSet = set.New()
 		m.mapOfSet[key] = innerSet
 	}
-
+	if m.mapOfSet[key].Has(value) {
+		result.Success = false
+		result.Value = value
+		return
+	}
 	m.mapOfSet[key].Add(value)
 	result.Success = true
 	result.Value = value

--- a/tools/mapset/map.go
+++ b/tools/mapset/map.go
@@ -25,8 +25,6 @@ type Result struct {
 var (
 	// ErrEmptyInput represents that the input into the operation is not complete
 	ErrEmptyInput = errors.New("One or more inputs are empty")
-	// ErrAlreadyExists represents when a value already exists in the set.
-	ErrAlreadyExists = errors.New("Already exists")
 )
 
 // Reserve will put a space into the map for the value given that key. Will return false if there is already an entry.
@@ -41,10 +39,6 @@ func (m *MapSet) Reserve(key string, value string) (result Result) {
 		m.mapOfSet[key] = innerSet
 	}
 
-	if m.mapOfSet[key].Has(value) {
-		result.Error = ErrAlreadyExists
-		return
-	}
 	m.mapOfSet[key].Add(value)
 	result.Success = true
 	result.Value = value

--- a/tools/mapset/map_test.go
+++ b/tools/mapset/map_test.go
@@ -17,7 +17,6 @@ var _ = Describe("Map", func() {
 		assert.Equal(GinkgoT(), expectedValue, res.Value)
 	},
 		Entry("Regular reservation", "key1", "value", nil, true, "value"),
-		Entry("Repeat reservation", "key1", "value", ErrAlreadyExists, false, ""),
 		Entry("no key", "", "value", ErrEmptyInput, false, ""),
 		Entry("no value", "key1", "", ErrEmptyInput, false, ""),
 	)

--- a/tools/mapset/map_test.go
+++ b/tools/mapset/map_test.go
@@ -17,6 +17,7 @@ var _ = Describe("Map", func() {
 		assert.Equal(GinkgoT(), expectedValue, res.Value)
 	},
 		Entry("Regular reservation", "key1", "value", nil, true, "value"),
+		Entry("Repeat reservation", "key1", "value", nil, false, "value"),
 		Entry("no key", "", "value", ErrEmptyInput, false, ""),
 		Entry("no value", "key1", "", ErrEmptyInput, false, ""),
 	)


### PR DESCRIPTION
I thought it might be handy to have both my standards and my certifications in the same repo:, https://github.com/pburkholder/freedonia-frist, and then refer to them in my `opencontrol.yaml` as follows, from 

```yaml
dependencies:
  standards:
    - url: https://github.com/pburkholder/freedonia-frist/
      revision: master
  certifications:
    - url: https://github.com/pburkholder/freedonia-frist/
      revision: master
```

When I tried this I got the following:

```bash
$ compliance-masonry --verbose get
2016/07/07 14:18:08 Running with verbosity
2016/07/07 14:18:08 Retrieving certifications
2016/07/07 14:18:08 Retrieving standards
2016/07/07 14:18:08 Retrieving components
2016/07/07 14:18:08 Ensuring directory /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/components exists
2016/07/07 14:18:08 Attempting to copy local resource AU_policy into /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/components/AU_policy
2016/07/07 14:18:08 Copying local resource AU_policy reursively into /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/components/AU_policy
2016/07/07 14:18:08 Retrieving dependent certifications
2016/07/07 14:18:08 Attempting to clone {https://github.com/pburkholder/freedonia-frist/ master } into /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources628003615/certifications/freedonia-frist
2016/07/07 14:18:08 Initializing repo https://github.com/pburkholder/freedonia-frist/ into /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources628003615/certifications/freedonia-frist
2016/07/07 14:18:09 Cloning https://github.com/pburkholder/freedonia-frist/ into /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources628003615/certifications/freedonia-frist
2016/07/07 14:18:09 Checking out revision master for repo https://github.com/pburkholder/freedonia-frist/
2016/07/07 14:18:09 Retrieving certifications
2016/07/07 14:18:09 Ensuring directory /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/certifications exists
2016/07/07 14:18:09 Attempting to copy local resource /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources628003615/certifications/freedonia-frist/certifications/FredRAMP-low.yaml into /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/certifications/FredRAMP-low.yaml
2016/07/07 14:18:09 Copying local resource /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources628003615/certifications/freedonia-frist/certifications/FredRAMP-low.yaml into /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/certifications/FredRAMP-low.yaml
2016/07/07 14:18:09 source /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources628003615/certifications/freedonia-frist/certifications/FredRAMP-low.yaml dest /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/certifications/FredRAMP-low.yaml
2016/07/07 14:18:09 Retrieving standards
2016/07/07 14:18:09 Ensuring directory /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/standards exists
2016/07/07 14:18:09 Attempting to copy local resource /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources628003615/certifications/freedonia-frist/standards/FRIST-800-53.yaml into /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/standards/FRIST-800-53.yaml
2016/07/07 14:18:09 Copying local resource /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources628003615/certifications/freedonia-frist/standards/FRIST-800-53.yaml into /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/standards/FRIST-800-53.yaml
2016/07/07 14:18:09 source /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources628003615/certifications/freedonia-frist/standards/FRIST-800-53.yaml dest /Users/pburkholder/Projects/pburkholder/freedonia-compliance/opencontrols/standards/FRIST-800-53.yaml
2016/07/07 14:18:09 Retrieving components
2016/07/07 14:18:09 Retrieving dependent certifications
2016/07/07 14:18:09 Retrieving dependent standards
2016/07/07 14:18:09 Retrieving dependent components
2016/07/07 14:18:09 Retrieving dependent standards
2016/07/07 14:18:09 Attempting to clone {https://github.com/pburkholder/freedonia-frist/ master } into /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources401044675/standards/freedonia-frist
2016/07/07 14:18:09 Initializing repo https://github.com/pburkholder/freedonia-frist/ into /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources401044675/standards/freedonia-frist
2016/07/07 14:18:09 Cloning https://github.com/pburkholder/freedonia-frist/ into /var/folders/hl/zf_j1bvs7_b18rj7bbsm35p00000gs/T/opencontrol-resources401044675/standards/freedonia-frist
2016/07/07 14:18:10 Checking out revision master for repo https://github.com/pburkholder/freedonia-frist/
2016/07/07 14:18:10 Retrieving certifications
Already exists
```

The error originates here: https://github.com/opencontrol/compliance-masonry/blob/master/config/common/resources/resourceGetter.go#L24-L26,

which in turn comes from `mapset.Reserve` per this PR. The `.Reserve` method doesn't seem to be used anywhere else in this project except at L24 of resourceGetter.go, and I'm not sure what error it's supposed to protect against, but it currently blocks what seems to be a valid use case.

I'm sure there's probably a better way to fix this, but I thought I'd start here.  All test still pass.