### PR TITLE
remove schema information for the opencontrol.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,39 +32,7 @@ Compliance Masonry is a command-line interface (CLI) that allows users to constr
     mkdir your-project-name && cd your-project-name
     ```
 
-1. Create an `opencontrol.yaml` files
-
-    ```bash
-    touch opencontrol.yaml
-    ```
-
-1. Edit the `opencontrol.yaml` to contain the following data:
-
-    ```yaml
-    schema_version: "1.0.0" # 1.0.0 is the current opencontrol.yaml schema version
-    name: Project_Name # Name of the project
-    metadata:
-      description: "A description of the system"
-      maintainers:
-        - maintainer_email@email.com
-    components: # A list of paths to components written in the opencontrol format for more information view: https://github.com/opencontrol/schemas
-      - ./component-1
-    certifications: # An optional list of certifications for more information visit: https://github.com/opencontrol/schemas
-      - ./cert-1.yaml
-    standards: # An optional list of standards for more information visit: https://github.com/opencontrol/schemas
-      - ./standard-1.yaml
-    dependencies:
-      certifications: # An optional list of certifications stored remotely
-        - url: https://github.com/18F/GSA-Certifications
-          revision: master
-      systems:  # An optional list of repos that contain an opencontrol.yaml stored remotely
-        - url: https://github.com/18F/cg-compliance
-          revision: master
-      standards:   # An optional list of remote repos containing standards info that contain an opencontrol.yaml
-        - url: https://github.com/opencontrol/NIST-800-53-Standards
-          revision: master
-    ```
-
+1. Create an [`opencontrol.yaml`](https://github.com/opencontrol/schemas#opencontrolyaml)
 1. Collect dependencies
 
     ```bash


### PR DESCRIPTION
All of the other information about the file schemas are in the schemas repository, so removing the opencontrol.yaml information here to be consistent. Depends on https://github.com/opencontrol/schemas/pull/36.