### PR TITLE
Update schema for control_origin and implementation_status

### DIFF
--- a/fixtures/component_fixtures/v3_1_0/EC2/component.yaml
+++ b/fixtures/component_fixtures/v3_1_0/EC2/component.yaml
@@ -12,6 +12,9 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  implementation_statuses:
+    - "partial"
+    - "planned"
   control_origin: shared
   control_origins:
     - "shared"
@@ -29,6 +32,8 @@ satisfies:
     system_key: CloudFoundry
     verification_key: UAA_Verification_1
   implementation_status: partial
+  implementation_statuses:
+    - "partial"
   control_origin: inherited
   control_origins:
     - "inherited"

--- a/fixtures/component_fixtures/v3_1_0/EC2/component.yaml
+++ b/fixtures/component_fixtures/v3_1_0/EC2/component.yaml
@@ -1,0 +1,78 @@
+documentation_complete: false
+name: Amazon Elastic Compute Cloud
+references:
+- name: Reference
+  path: http://VerificationURL.com
+  type: URL
+satisfies:
+- control_key: CM-2
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
+  implementation_status: partial
+  control_origin: shared
+  control_origins:
+    - "shared"
+    - "inherited"
+  narrative:
+    - key: "a"
+      text: "Justification in narrative form A for CM-2"
+    - key: "b"
+      text: "Justification in narrative form B for CM-2"
+  standard_key: NIST-800-53
+- control_key: 1.1
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
+  implementation_status: partial
+  control_origin: inherited
+  control_origins:
+    - "inherited"
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1"
+    - key: "b"
+      text: "Parameter B for 1.1"
+  narrative:
+    - key: "a"
+      text: "Justification in narrative form A for 1.1"
+    - key: "b"
+      text: "Justification in narrative form B for 1.1"
+  standard_key: PCI-DSS-MAY-2015
+- control_key: 1.1.1
+  covered_by: []
+  implementation_status: partial
+  control_origin: inherited
+  narrative:
+    - key: "a"
+      text: "Justification in narrative form A for 1.1.1"
+    - key: "b"
+      text: "Justification in narrative form B for 1.1.1"
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1.1"
+    - key: "b"
+      text: "Parameter B for 1.1.1"
+  standard_key: PCI-DSS-MAY-2015
+- control_key: 2.1
+  covered_by: []
+  implementation_status: partial
+  control_origin: inherited
+  narrative:
+    - text: "Justification in narrative form for 2.1"
+  standard_key: PCI-DSS-MAY-2015
+responsible_role: "AWS Staff"
+schema_version: 3.1.0
+verifications:
+- key: EC2_Verification_2
+  name: EC2 Governor 2
+  path: artifact-ec2-1.png
+  type: Image
+- key: EC2_Verification_1
+  name: EC2 Verification 1
+  path: http://VerificationURL.com
+  type: URL

--- a/fixtures/component_fixtures/v3_1_0/EC2WithKey/component.yaml
+++ b/fixtures/component_fixtures/v3_1_0/EC2WithKey/component.yaml
@@ -17,6 +17,10 @@ satisfies:
   control_origins:
     - "shared"
     - "inherited"
+  implementation_status: partial
+  implementation_statuses:
+    - "partial"
+    - "planned"  
   narrative:
     - key: "a"
       text: "Justification in narrative form A for CM-2"

--- a/fixtures/component_fixtures/v3_1_0/EC2WithKey/component.yaml
+++ b/fixtures/component_fixtures/v3_1_0/EC2WithKey/component.yaml
@@ -1,0 +1,79 @@
+documentation_complete: false
+name: Amazon Elastic Compute Cloud
+key: EC2
+references:
+- name: Reference
+  path: http://VerificationURL.com
+  type: URL
+satisfies:
+- control_key: CM-2
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
+  implementation_status: partial
+  control_origin: shared
+  control_origins:
+    - "shared"
+    - "inherited"
+  narrative:
+    - key: "a"
+      text: "Justification in narrative form A for CM-2"
+    - key: "b"
+      text: "Justification in narrative form B for CM-2"
+  standard_key: NIST-800-53
+- control_key: 1.1
+  covered_by:
+  - verification_key: EC2_Verification_1
+  - component_key: UAA
+    system_key: CloudFoundry
+    verification_key: UAA_Verification_1
+  implementation_status: partial
+  control_origin: inherited
+  control_origins:
+    - "inherited"
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1"
+    - key: "b"
+      text: "Parameter B for 1.1"
+  narrative:
+    - key: "a"
+      text: "Justification in narrative form A for 1.1"
+    - key: "b"
+      text: "Justification in narrative form B for 1.1"
+  standard_key: PCI-DSS-MAY-2015
+- control_key: 1.1.1
+  covered_by: []
+  implementation_status: partial
+  control_origin: inherited
+  narrative:
+    - key: "a"
+      text: "Justification in narrative form A for 1.1.1"
+    - key: "b"
+      text: "Justification in narrative form B for 1.1.1"
+  parameters:
+    - key: "a"
+      text: "Parameter A for 1.1.1"
+    - key: "b"
+      text: "Parameter B for 1.1.1"
+  standard_key: PCI-DSS-MAY-2015
+- control_key: 2.1
+  covered_by: []
+  implementation_status: partial
+  control_origin: inherited
+  narrative:
+    - text: "Justification in narrative form for 2.1"
+  standard_key: PCI-DSS-MAY-2015
+responsible_role: "AWS Staff"
+schema_version: 3.0.0
+verifications:
+- key: EC2_Verification_2
+  name: EC2 Governor 2
+  path: artifact-ec2-1.png
+  type: Image
+- key: EC2_Verification_1
+  name: EC2 Verification 1
+  path: http://VerificationURL.com
+  type: URL

--- a/models/components/versions/2_0_0/component.go
+++ b/models/components/versions/2_0_0/component.go
@@ -119,3 +119,7 @@ func (n Narrative) GetText() string {
 func (s Satisfies) GetImplementationStatus() string {
 	return s.ImplementationStatus
 }
+
+func (s Satisfies) GetImplementationStatuses() []string {
+	return []string{}
+}

--- a/models/components/versions/2_0_0/component.go
+++ b/models/components/versions/2_0_0/component.go
@@ -63,10 +63,11 @@ func (c Component) GetResponsibleRole() string {
 // This struct is a one-to-one mapping of a `satisfies` item in the component.yaml schema
 // https://github.com/opencontrol/schemas#component-yaml
 type Satisfies struct {
-	ControlKey  string               `yaml:"control_key" json:"control_key"`
-	StandardKey string               `yaml:"standard_key" json:"standard_key"`
-	Narrative   Narrative            `yaml:"narrative" json:"narrative"`
-	CoveredBy   common.CoveredByList `yaml:"covered_by" json:"covered_by"`
+	ControlKey           string               `yaml:"control_key" json:"control_key"`
+	StandardKey          string               `yaml:"standard_key" json:"standard_key"`
+	Narrative            Narrative            `yaml:"narrative" json:"narrative"`
+	CoveredBy            common.CoveredByList `yaml:"covered_by" json:"covered_by"`
+	ImplementationStatus string               `yaml:"implementation_status" json:"implementation_status"`
 }
 
 func (s Satisfies) GetControlKey() string {
@@ -113,4 +114,8 @@ func (n Narrative) GetKey() string {
 
 func (n Narrative) GetText() string {
 	return string(n)
+}
+
+func (s Satisfies) GetImplementationStatus() string {
+	return s.ImplementationStatus
 }

--- a/models/components/versions/2_0_0/component.go
+++ b/models/components/versions/2_0_0/component.go
@@ -1,20 +1,20 @@
 package component
 
 import (
-	"github.com/opencontrol/compliance-masonry/models/components/versions/base"
-	"github.com/opencontrol/compliance-masonry/models/common"
 	"github.com/blang/semver"
+	"github.com/opencontrol/compliance-masonry/models/common"
+	"github.com/opencontrol/compliance-masonry/models/components/versions/base"
 )
 
 // Component struct is an individual component requiring documentation
 // Schema info: https://github.com/opencontrol/schemas#component-yaml
 type Component struct {
-	Name          string                  `yaml:"name" json:"name"`
-	Key           string                  `yaml:"key" json:"key"`
+	Name          string                        `yaml:"name" json:"name"`
+	Key           string                        `yaml:"key" json:"key"`
 	References    common.GeneralReferences      `yaml:"references" json:"references"`
 	Verifications common.VerificationReferences `yaml:"verifications" json:"verifications"`
-	Satisfies     []Satisfies          `yaml:"satisfies" json:"satisfies"`
-	SchemaVersion semver.Version                 `yaml:"-" json:"-"`
+	Satisfies     []Satisfies                   `yaml:"satisfies" json:"satisfies"`
+	SchemaVersion semver.Version                `yaml:"-" json:"-"`
 }
 
 func (c Component) GetName() string {
@@ -63,9 +63,9 @@ func (c Component) GetResponsibleRole() string {
 // This struct is a one-to-one mapping of a `satisfies` item in the component.yaml schema
 // https://github.com/opencontrol/schemas#component-yaml
 type Satisfies struct {
-	ControlKey  string        `yaml:"control_key" json:"control_key"`
-	StandardKey string        `yaml:"standard_key" json:"standard_key"`
-	Narrative   Narrative        `yaml:"narrative" json:"narrative"`
+	ControlKey  string               `yaml:"control_key" json:"control_key"`
+	StandardKey string               `yaml:"standard_key" json:"standard_key"`
+	Narrative   Narrative            `yaml:"narrative" json:"narrative"`
 	CoveredBy   common.CoveredByList `yaml:"covered_by" json:"covered_by"`
 }
 
@@ -99,6 +99,10 @@ func (s Satisfies) GetCoveredBy() common.CoveredByList {
 
 func (s Satisfies) GetControlOrigin() string {
 	return ""
+}
+
+func (s Satisfies) GetControlOrigins() []string {
+	return []string{}
 }
 
 type Narrative string

--- a/models/components/versions/2_0_0/component_test.go
+++ b/models/components/versions/2_0_0/component_test.go
@@ -36,9 +36,10 @@ func TestComponentGetters(t *testing.T) {
 		}
 		assert.Equal(t, satisfies.GetParameters(), testSatisfies[idx].GetParameters())
 		assert.Equal(t, satisfies.GetCoveredBy(), testSatisfies[idx].GetCoveredBy())
-		assert.Equal(t, "", satisfies.GetControlOrigin())
-		assert.Equal(t, []string{}, satisfies.GetControlOrigins())
-		assert.Equal(t, "", satisfies.GetImplementationStatus())
+		assert.Equal(t, satisfies.GetControlOrigin(), "")
+		assert.Equal(t, satisfies.GetControlOrigins(), []string{})
+		assert.Equal(t, satisfies.GetImplementationStatus(), "")
+		assert.Equal(t, satisfies.GetImplementationStatuses(), []string{})
 	}
 }
 

--- a/models/components/versions/2_0_0/component_test.go
+++ b/models/components/versions/2_0_0/component_test.go
@@ -2,13 +2,14 @@ package component
 
 import (
 	"testing"
+
+	"github.com/blang/semver"
 	"github.com/opencontrol/compliance-masonry/models/common"
 	"github.com/stretchr/testify/assert"
-	"github.com/blang/semver"
 )
 
 func TestComponentGetters(t *testing.T) {
-	testSatisfies := []Satisfies{{Narrative: "Narrative"}, {}, {}, {}}
+	testSatisfies := []Satisfies{{Narrative: "Narrative"}, {}, {}, {}, {}}
 	component := Component{
 		Name:          "Amazon Elastic Compute Cloud",
 		Key:           "EC2",
@@ -36,6 +37,7 @@ func TestComponentGetters(t *testing.T) {
 		assert.Equal(t, satisfies.GetParameters(), testSatisfies[idx].GetParameters())
 		assert.Equal(t, satisfies.GetCoveredBy(), testSatisfies[idx].GetCoveredBy())
 		assert.Equal(t, "", satisfies.GetControlOrigin())
+		assert.Equal(t, "", satisfies.GetImplementationStatus())
 	}
 }
 

--- a/models/components/versions/2_0_0/component_test.go
+++ b/models/components/versions/2_0_0/component_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestComponentGetters(t *testing.T) {
-	testSatisfies := []Satisfies{{Narrative: "Narrative"}, {}, {}, {}, {}}
+	testSatisfies := []Satisfies{{Narrative: "Narrative"}, {}, {}}
 	component := Component{
 		Name:          "Amazon Elastic Compute Cloud",
 		Key:           "EC2",
@@ -37,6 +37,7 @@ func TestComponentGetters(t *testing.T) {
 		assert.Equal(t, satisfies.GetParameters(), testSatisfies[idx].GetParameters())
 		assert.Equal(t, satisfies.GetCoveredBy(), testSatisfies[idx].GetCoveredBy())
 		assert.Equal(t, "", satisfies.GetControlOrigin())
+		assert.Equal(t, []string{}, satisfies.GetControlOrigins())
 		assert.Equal(t, "", satisfies.GetImplementationStatus())
 	}
 }

--- a/models/components/versions/3_0_0/component.go
+++ b/models/components/versions/3_0_0/component.go
@@ -115,6 +115,10 @@ func (s Satisfies) GetImplementationStatus() string {
 	return s.ImplementationStatus
 }
 
+func (s Satisfies) GetImplementationStatuses() []string {
+	return []string{}
+}
+
 // NarrativeSection contains the key and text for a particular section.
 // NarrativeSection can omit the key.
 type NarrativeSection struct {

--- a/models/components/versions/3_0_0/component.go
+++ b/models/components/versions/3_0_0/component.go
@@ -64,12 +64,13 @@ func (c Component) GetResponsibleRole() string {
 // This struct is a one-to-one mapping of a `satisfies` item in the component.yaml schema
 // https://github.com/opencontrol/schemas#component-yaml
 type Satisfies struct {
-	ControlKey    string               `yaml:"control_key" json:"control_key"`
-	StandardKey   string               `yaml:"standard_key" json:"standard_key"`
-	Narrative     []NarrativeSection   `yaml:"narrative" json:"narrative"`
-	CoveredBy     common.CoveredByList `yaml:"covered_by" json:"covered_by"`
-	Parameters    []Section            `yaml:"parameters" json:"parameters"`
-	ControlOrigin string               `yaml:"control_origin" json:"control_origin"`
+	ControlKey           string               `yaml:"control_key" json:"control_key"`
+	StandardKey          string               `yaml:"standard_key" json:"standard_key"`
+	Narrative            []NarrativeSection   `yaml:"narrative" json:"narrative"`
+	CoveredBy            common.CoveredByList `yaml:"covered_by" json:"covered_by"`
+	Parameters           []Section            `yaml:"parameters" json:"parameters"`
+	ControlOrigin        string               `yaml:"control_origin" json:"control_origin"`
+	ImplementationStatus string               `yaml:"implementation_status" json:"implementation_status"`
 }
 
 func (s Satisfies) GetControlKey() string {
@@ -108,6 +109,10 @@ func (s Satisfies) GetControlOrigin() string {
 
 func (s Satisfies) GetControlOrigins() []string {
 	return []string{s.ControlOrigin}
+}
+
+func (s Satisfies) GetImplementationStatus() string {
+	return s.ImplementationStatus
 }
 
 // NarrativeSection contains the key and text for a particular section.

--- a/models/components/versions/3_0_0/component_test.go
+++ b/models/components/versions/3_0_0/component_test.go
@@ -2,21 +2,22 @@ package component
 
 import (
 	"testing"
+
+	"github.com/blang/semver"
 	"github.com/opencontrol/compliance-masonry/models/common"
 	"github.com/stretchr/testify/assert"
-	"github.com/blang/semver"
 )
 
 func TestComponentGetters(t *testing.T) {
-	testSatisfies := []Satisfies{{ControlOrigin: "control_origin", Parameters: []Section{Section{Key:"key", Text: "text"}}, Narrative: []NarrativeSection{NarrativeSection{Key: "key", Text: "text"}, NarrativeSection{Text: "text"}}}, {}, {}, {}}
+	testSatisfies := []Satisfies{{ControlOrigin: "control_origin", Parameters: []Section{Section{Key: "key", Text: "text"}}, Narrative: []NarrativeSection{NarrativeSection{Key: "key", Text: "text"}, NarrativeSection{Text: "text"}}}, {}, {}, {}}
 	component := Component{
-		Name:          "Amazon Elastic Compute Cloud",
-		Key:           "EC2",
+		Name:            "Amazon Elastic Compute Cloud",
+		Key:             "EC2",
 		ResponsibleRole: "AWS Staff",
-		References:    common.GeneralReferences{{}},
-		Verifications: common.VerificationReferences{{}, {}},
-		Satisfies:     testSatisfies,
-		SchemaVersion: semver.MustParse("3.0.0"),
+		References:      common.GeneralReferences{{}},
+		Verifications:   common.VerificationReferences{{}, {}},
+		Satisfies:       testSatisfies,
+		SchemaVersion:   semver.MustParse("3.0.0"),
 	}
 	// Test the getters
 	assert.Equal(t, "EC2", component.GetKey())
@@ -41,6 +42,7 @@ func TestComponentGetters(t *testing.T) {
 		}
 		assert.Equal(t, satisfies.GetCoveredBy(), testSatisfies[idx].GetCoveredBy())
 		assert.Equal(t, satisfies.GetControlOrigin(), testSatisfies[idx].GetControlOrigin())
+		assert.Equal(t, satisfies.GetImplementationStatus(), testSatisfies[idx].GetImplementationStatus())
 	}
 }
 

--- a/models/components/versions/3_0_0/component_test.go
+++ b/models/components/versions/3_0_0/component_test.go
@@ -44,6 +44,7 @@ func TestComponentGetters(t *testing.T) {
 		assert.Equal(t, satisfies.GetControlOrigin(), testSatisfies[idx].GetControlOrigin())
 		assert.Equal(t, []string{satisfies.GetControlOrigin()}, satisfies.GetControlOrigins())
 		assert.Equal(t, satisfies.GetImplementationStatus(), testSatisfies[idx].GetImplementationStatus())
+		assert.Equal(t, satisfies.GetImplementationStatuses(), []string{})
 	}
 }
 

--- a/models/components/versions/3_0_0/component_test.go
+++ b/models/components/versions/3_0_0/component_test.go
@@ -42,6 +42,7 @@ func TestComponentGetters(t *testing.T) {
 		}
 		assert.Equal(t, satisfies.GetCoveredBy(), testSatisfies[idx].GetCoveredBy())
 		assert.Equal(t, satisfies.GetControlOrigin(), testSatisfies[idx].GetControlOrigin())
+		assert.Equal(t, []string{}, satisfies.GetControlOrigins())
 		assert.Equal(t, satisfies.GetImplementationStatus(), testSatisfies[idx].GetImplementationStatus())
 	}
 }

--- a/models/components/versions/3_0_0/component_test.go
+++ b/models/components/versions/3_0_0/component_test.go
@@ -42,7 +42,7 @@ func TestComponentGetters(t *testing.T) {
 		}
 		assert.Equal(t, satisfies.GetCoveredBy(), testSatisfies[idx].GetCoveredBy())
 		assert.Equal(t, satisfies.GetControlOrigin(), testSatisfies[idx].GetControlOrigin())
-		assert.Equal(t, []string{}, satisfies.GetControlOrigins())
+		assert.Equal(t, []string{satisfies.GetControlOrigin()}, satisfies.GetControlOrigins())
 		assert.Equal(t, satisfies.GetImplementationStatus(), testSatisfies[idx].GetImplementationStatus())
 	}
 }

--- a/models/components/versions/3_1_0/component.go
+++ b/models/components/versions/3_1_0/component.go
@@ -65,13 +65,14 @@ func (c Component) GetResponsibleRole() string {
 // This struct is a one-to-one mapping of a `satisfies` item in the component.yaml schema
 // https://github.com/opencontrol/schemas#component-yaml
 type Satisfies struct {
-	ControlKey     string               `yaml:"control_key" json:"control_key"`
-	StandardKey    string               `yaml:"standard_key" json:"standard_key"`
-	Narrative      []NarrativeSection   `yaml:"narrative" json:"narrative"`
-	CoveredBy      common.CoveredByList `yaml:"covered_by" json:"covered_by"`
-	Parameters     []Section            `yaml:"parameters" json:"parameters"`
-	ControlOrigin  string               `yaml:"control_origin" json:"control_origin"`
-	ControlOrigins []string             `yaml:"control_origins" json:"control_origins"`
+	ControlKey           string               `yaml:"control_key" json:"control_key"`
+	StandardKey          string               `yaml:"standard_key" json:"standard_key"`
+	Narrative            []NarrativeSection   `yaml:"narrative" json:"narrative"`
+	CoveredBy            common.CoveredByList `yaml:"covered_by" json:"covered_by"`
+	Parameters           []Section            `yaml:"parameters" json:"parameters"`
+	ControlOrigin        string               `yaml:"control_origin" json:"control_origin"`
+	ControlOrigins       []string             `yaml:"control_origins" json:"control_origins"`
+	ImplementationStatus string               `yaml:"implementation_status" json:"implementation_status"`
 }
 
 func (s Satisfies) GetControlKey() string {
@@ -117,6 +118,10 @@ func (s Satisfies) GetControlOrigins() []string {
 		controlOrigins.Add(s.ControlOrigin)
 	}
 	return set.StringSlice(controlOrigins)
+}
+
+func (s Satisfies) GetImplementationStatus() string {
+	return s.ImplementationStatus
 }
 
 // NarrativeSection contains the key and text for a particular section.

--- a/models/components/versions/3_1_0/component.go
+++ b/models/components/versions/3_1_0/component.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"sort"
+
 	"github.com/blang/semver"
 	"github.com/opencontrol/compliance-masonry/models/common"
 	"github.com/opencontrol/compliance-masonry/models/components/versions/base"
@@ -65,14 +67,15 @@ func (c Component) GetResponsibleRole() string {
 // This struct is a one-to-one mapping of a `satisfies` item in the component.yaml schema
 // https://github.com/opencontrol/schemas#component-yaml
 type Satisfies struct {
-	ControlKey           string               `yaml:"control_key" json:"control_key"`
-	StandardKey          string               `yaml:"standard_key" json:"standard_key"`
-	Narrative            []NarrativeSection   `yaml:"narrative" json:"narrative"`
-	CoveredBy            common.CoveredByList `yaml:"covered_by" json:"covered_by"`
-	Parameters           []Section            `yaml:"parameters" json:"parameters"`
-	ControlOrigin        string               `yaml:"control_origin" json:"control_origin"`
-	ControlOrigins       []string             `yaml:"control_origins" json:"control_origins"`
-	ImplementationStatus string               `yaml:"implementation_status" json:"implementation_status"`
+	ControlKey             string               `yaml:"control_key" json:"control_key"`
+	StandardKey            string               `yaml:"standard_key" json:"standard_key"`
+	Narrative              []NarrativeSection   `yaml:"narrative" json:"narrative"`
+	CoveredBy              common.CoveredByList `yaml:"covered_by" json:"covered_by"`
+	Parameters             []Section            `yaml:"parameters" json:"parameters"`
+	ControlOrigin          string               `yaml:"control_origin" json:"control_origin"`
+	ControlOrigins         []string             `yaml:"control_origins" json:"control_origins"`
+	ImplementationStatus   string               `yaml:"implementation_status" json:"implementation_status"`
+	ImplementationStatuses []string             `yaml:"implementation_statuses" json:"implementation_statuses"`
 }
 
 func (s Satisfies) GetControlKey() string {
@@ -117,11 +120,26 @@ func (s Satisfies) GetControlOrigins() []string {
 	if s.ControlOrigin != "" {
 		controlOrigins.Add(s.ControlOrigin)
 	}
-	return set.StringSlice(controlOrigins)
+	l := set.StringSlice(controlOrigins)
+	sort.Strings(l)
+	return l
 }
 
 func (s Satisfies) GetImplementationStatus() string {
 	return s.ImplementationStatus
+}
+
+func (s Satisfies) GetImplementationStatuses() []string {
+	implementationStatuses := set.New()
+	for i := range s.ImplementationStatuses {
+		implementationStatuses.Add(s.ImplementationStatuses[i])
+	}
+	if s.ImplementationStatus != "" {
+		implementationStatuses.Add(s.ImplementationStatus)
+	}
+	l := set.StringSlice(implementationStatuses)
+	sort.Strings(l)
+	return l
 }
 
 // NarrativeSection contains the key and text for a particular section.

--- a/models/components/versions/3_1_0/component.go
+++ b/models/components/versions/3_1_0/component.go
@@ -4,6 +4,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/opencontrol/compliance-masonry/models/common"
 	"github.com/opencontrol/compliance-masonry/models/components/versions/base"
+	"gopkg.in/fatih/set.v0"
 )
 
 // Component struct is an individual component requiring documentation
@@ -64,12 +65,13 @@ func (c Component) GetResponsibleRole() string {
 // This struct is a one-to-one mapping of a `satisfies` item in the component.yaml schema
 // https://github.com/opencontrol/schemas#component-yaml
 type Satisfies struct {
-	ControlKey    string               `yaml:"control_key" json:"control_key"`
-	StandardKey   string               `yaml:"standard_key" json:"standard_key"`
-	Narrative     []NarrativeSection   `yaml:"narrative" json:"narrative"`
-	CoveredBy     common.CoveredByList `yaml:"covered_by" json:"covered_by"`
-	Parameters    []Section            `yaml:"parameters" json:"parameters"`
-	ControlOrigin string               `yaml:"control_origin" json:"control_origin"`
+	ControlKey     string               `yaml:"control_key" json:"control_key"`
+	StandardKey    string               `yaml:"standard_key" json:"standard_key"`
+	Narrative      []NarrativeSection   `yaml:"narrative" json:"narrative"`
+	CoveredBy      common.CoveredByList `yaml:"covered_by" json:"covered_by"`
+	Parameters     []Section            `yaml:"parameters" json:"parameters"`
+	ControlOrigin  string               `yaml:"control_origin" json:"control_origin"`
+	ControlOrigins []string             `yaml:"control_origins" json:"control_origins"`
 }
 
 func (s Satisfies) GetControlKey() string {
@@ -107,7 +109,14 @@ func (s Satisfies) GetControlOrigin() string {
 }
 
 func (s Satisfies) GetControlOrigins() []string {
-	return []string{s.ControlOrigin}
+	controlOrigins := set.New()
+	for i := range s.ControlOrigins {
+		controlOrigins.Add(s.ControlOrigins[i])
+	}
+	if s.ControlOrigin != "" {
+		controlOrigins.Add(s.ControlOrigin)
+	}
+	return set.StringSlice(controlOrigins)
 }
 
 // NarrativeSection contains the key and text for a particular section.

--- a/models/components/versions/3_1_0/component_test.go
+++ b/models/components/versions/3_1_0/component_test.go
@@ -44,6 +44,7 @@ func TestComponentGetters(t *testing.T) {
 		assert.Equal(t, satisfies.GetControlOrigin(), testSatisfies[idx].GetControlOrigin())
 		assert.Equal(t, satisfies.GetControlOrigins(), testSatisfies[idx].GetControlOrigins())
 		assert.Equal(t, satisfies.GetImplementationStatus(), testSatisfies[idx].GetImplementationStatus())
+		assert.Equal(t, satisfies.GetImplementationStatuses(), testSatisfies[idx].GetImplementationStatuses())
 	}
 }
 

--- a/models/components/versions/3_1_0/component_test.go
+++ b/models/components/versions/3_1_0/component_test.go
@@ -1,0 +1,58 @@
+package component
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/opencontrol/compliance-masonry/models/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComponentGetters(t *testing.T) {
+	testSatisfies := []Satisfies{{ControlOrigin: "control_origin", Parameters: []Section{Section{Key: "key", Text: "text"}}, Narrative: []NarrativeSection{NarrativeSection{Key: "key", Text: "text"}, NarrativeSection{Text: "text"}}}, {}, {}, {}}
+	component := Component{
+		Name:            "Amazon Elastic Compute Cloud",
+		Key:             "EC2",
+		ResponsibleRole: "AWS Staff",
+		References:      common.GeneralReferences{{}},
+		Verifications:   common.VerificationReferences{{}, {}},
+		Satisfies:       testSatisfies,
+		SchemaVersion:   semver.MustParse("3.1.0"),
+	}
+	// Test the getters
+	assert.Equal(t, "EC2", component.GetKey())
+	assert.Equal(t, "Amazon Elastic Compute Cloud", component.GetName())
+	assert.Equal(t, &common.GeneralReferences{{}}, component.GetReferences())
+	assert.Equal(t, &common.VerificationReferences{{}, {}}, component.GetVerifications())
+	assert.Equal(t, semver.MustParse("3.1.0"), component.GetVersion())
+	assert.Equal(t, "AWS Staff", component.GetResponsibleRole())
+	assert.Equal(t, len(testSatisfies), len(component.GetAllSatisfies()))
+	for idx, satisfies := range component.GetAllSatisfies() {
+		assert.Equal(t, satisfies.GetControlKey(), testSatisfies[idx].GetControlKey())
+		assert.Equal(t, satisfies.GetStandardKey(), testSatisfies[idx].GetStandardKey())
+		assert.Equal(t, satisfies.GetNarratives(), testSatisfies[idx].GetNarratives())
+		for i, narrative := range satisfies.GetNarratives() {
+			assert.Equal(t, satisfies.GetNarratives()[i].GetKey(), narrative.GetKey())
+			assert.Equal(t, satisfies.GetNarratives()[i].GetText(), narrative.GetText())
+		}
+		assert.Equal(t, satisfies.GetParameters(), testSatisfies[idx].GetParameters())
+		for i, parameter := range satisfies.GetParameters() {
+			assert.Equal(t, satisfies.GetParameters()[i].GetKey(), parameter.GetKey())
+			assert.Equal(t, satisfies.GetParameters()[i].GetText(), parameter.GetText())
+		}
+		assert.Equal(t, satisfies.GetCoveredBy(), testSatisfies[idx].GetCoveredBy())
+		assert.Equal(t, satisfies.GetControlOrigin(), testSatisfies[idx].GetControlOrigin())
+		assert.Equal(t, satisfies.GetControlOrigins(), testSatisfies[idx].GetControlOrigins())
+	}
+}
+
+func TestComponentSetters(t *testing.T) {
+	component := Component{}
+	// Test the setters.
+	// Change the version.
+	component.SetVersion(semver.MustParse("3.1.0"))
+	assert.Equal(t, semver.MustParse("3.1.0"), component.GetVersion())
+	// Change the key.
+	component.SetKey("FooKey")
+	assert.Equal(t, "FooKey", component.GetKey())
+}

--- a/models/components/versions/3_1_0/component_test.go
+++ b/models/components/versions/3_1_0/component_test.go
@@ -43,6 +43,7 @@ func TestComponentGetters(t *testing.T) {
 		assert.Equal(t, satisfies.GetCoveredBy(), testSatisfies[idx].GetCoveredBy())
 		assert.Equal(t, satisfies.GetControlOrigin(), testSatisfies[idx].GetControlOrigin())
 		assert.Equal(t, satisfies.GetControlOrigins(), testSatisfies[idx].GetControlOrigins())
+		assert.Equal(t, satisfies.GetImplementationStatus(), testSatisfies[idx].GetImplementationStatus())
 	}
 }
 

--- a/models/components/versions/3_1_0/component_test.go
+++ b/models/components/versions/3_1_0/component_test.go
@@ -9,7 +9,18 @@ import (
 )
 
 func TestComponentGetters(t *testing.T) {
-	testSatisfies := []Satisfies{{ControlOrigin: "control_origin", Parameters: []Section{Section{Key: "key", Text: "text"}}, Narrative: []NarrativeSection{NarrativeSection{Key: "key", Text: "text"}, NarrativeSection{Text: "text"}}}, {}, {}, {}}
+	testSatisfies := []Satisfies{
+		{
+			ControlOrigin:          "inherited",
+			ControlOrigins:         []string{"inherited"},
+			ImplementationStatus:   "partial",
+			ImplementationStatuses: []string{"partial"},
+			Parameters:             []Section{Section{Key: "key", Text: "text"}},
+			Narrative: []NarrativeSection{
+				NarrativeSection{Key: "key", Text: "text"},
+				NarrativeSection{Text: "text"},
+			},
+		}, {}}
 	component := Component{
 		Name:            "Amazon Elastic Compute Cloud",
 		Key:             "EC2",

--- a/models/components/versions/base/component.go
+++ b/models/components/versions/base/component.go
@@ -28,6 +28,7 @@ type Satisfies interface {
 	GetCoveredBy() common.CoveredByList
 	GetControlOrigin() string
 	GetControlOrigins() []string
+	GetImplementationStatus() string
 }
 
 type Section interface {

--- a/models/components/versions/base/component.go
+++ b/models/components/versions/base/component.go
@@ -1,9 +1,10 @@
 package base
 
 import (
-	"github.com/opencontrol/compliance-masonry/models/common"
-	"github.com/blang/semver"
 	"fmt"
+
+	"github.com/blang/semver"
+	"github.com/opencontrol/compliance-masonry/models/common"
 	"github.com/opencontrol/compliance-masonry/tools/constants"
 )
 
@@ -26,6 +27,7 @@ type Satisfies interface {
 	GetParameters() []Section
 	GetCoveredBy() common.CoveredByList
 	GetControlOrigin() string
+	GetControlOrigins() []string
 }
 
 type Section interface {

--- a/models/components/versions/base/component.go
+++ b/models/components/versions/base/component.go
@@ -29,6 +29,7 @@ type Satisfies interface {
 	GetControlOrigin() string
 	GetControlOrigins() []string
 	GetImplementationStatus() string
+	GetImplementationStatuses() []string
 }
 
 type Section interface {

--- a/models/components/versions/parse.go
+++ b/models/components/versions/parse.go
@@ -1,18 +1,21 @@
 package versions
 
 import (
-	"github.com/opencontrol/compliance-masonry/models/components/versions/base"
-	"gopkg.in/yaml.v2"
+	"fmt"
+
+	"github.com/blang/semver"
+	"github.com/opencontrol/compliance-masonry/config"
 	v2 "github.com/opencontrol/compliance-masonry/models/components/versions/2_0_0"
 	v3 "github.com/opencontrol/compliance-masonry/models/components/versions/3_0_0"
-	"github.com/opencontrol/compliance-masonry/config"
-	"fmt"
-	"github.com/blang/semver"
+	v31 "github.com/opencontrol/compliance-masonry/models/components/versions/3_1_0"
+	"github.com/opencontrol/compliance-masonry/models/components/versions/base"
+	"gopkg.in/yaml.v2"
 )
 
 var (
 	ComponentV2_0_0 = semver.MustParse("2.0.0")
 	ComponentV3_0_0 = semver.MustParse("3.0.0")
+	ComponentV3_1_0 = semver.MustParse("3.1.0")
 )
 
 func ParseComponent(componentData []byte, fileName string) (base.Component, error) {
@@ -37,12 +40,16 @@ func ParseComponent(componentData []byte, fileName string) (base.Component, erro
 		c := new(v3.Component)
 		err = yaml.Unmarshal(componentData, c)
 		component = c
+	case ComponentV3_1_0.EQ(b.SchemaVersion):
+		c := new(v31.Component)
+		err = yaml.Unmarshal(componentData, c)
+		component = c
 	default:
 		return nil, config.ErrUnknownSchemaVersion
 
 	}
 	if err != nil {
-		return nil, fmt.Errorf("Unable to parse component. Please check component.yaml schema for version %s\n" +
+		return nil, fmt.Errorf("Unable to parse component. Please check component.yaml schema for version %s\n"+
 			"\tFile: %v\n\tParse error: %v", b.SchemaVersion.String(), fileName, err)
 	}
 	// Copy version from base because some versions of the component can not expect to parse directly into it's own struct

--- a/models/components/versions/parse_test.go
+++ b/models/components/versions/parse_test.go
@@ -1,20 +1,27 @@
 package versions_test
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
+
+	"github.com/blang/semver"
+	"github.com/opencontrol/compliance-masonry/config"
+	"github.com/opencontrol/compliance-masonry/models"
+	"github.com/opencontrol/compliance-masonry/models/common"
+	"github.com/opencontrol/compliance-masonry/models/components"
 	v2 "github.com/opencontrol/compliance-masonry/models/components/versions/2_0_0"
 	v3 "github.com/opencontrol/compliance-masonry/models/components/versions/3_0_0"
-	"github.com/opencontrol/compliance-masonry/models/common"
+	v31 "github.com/opencontrol/compliance-masonry/models/components/versions/3_1_0"
 	"github.com/opencontrol/compliance-masonry/models/components/versions/base"
-	"github.com/stretchr/testify/assert"
-	"github.com/opencontrol/compliance-masonry/models"
-	"github.com/opencontrol/compliance-masonry/models/components"
 	"github.com/opencontrol/compliance-masonry/tools/constants"
-	"github.com/opencontrol/compliance-masonry/config"
-	"github.com/blang/semver"
-	"errors"
+	"github.com/stretchr/testify/assert"
 )
+
+type componentV3_1Test struct {
+	componentDir string
+	expected     v31.Component
+}
 
 type componentV3Test struct {
 	componentDir string
@@ -31,12 +38,67 @@ type componentTestError struct {
 	expectedError error
 }
 
-var v3Satisfies = []v3.Satisfies {
+var v3_1Satisfies = []v31.Satisfies{
+	{
+		Narrative: []v31.NarrativeSection{
+			v31.NarrativeSection{Key: "a", Text: "Justification in narrative form A for CM-2"},
+			v31.NarrativeSection{Key: "b", Text: "Justification in narrative form B for CM-2"},
+		},
+		ControlOrigin:  "shared",
+		ControlOrigins: []string{"shared", "inherited"},
+	},
+	{
+		Narrative: []v31.NarrativeSection{
+			v31.NarrativeSection{Key: "a", Text: "Justification in narrative form A for 1.1"},
+			v31.NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1"},
+		},
+		Parameters: []v31.Section{
+			v31.Section{Key: "a", Text: "Parameter A for 1.1"},
+			v31.Section{Key: "b", Text: "Parameter B for 1.1"},
+		},
+		ControlOrigin:  "inherited",
+		ControlOrigins: []string{"inherited"},
+	},
+	{
+		Narrative: []v31.NarrativeSection{
+			v31.NarrativeSection{Key: "a", Text: "Justification in narrative form A for 1.1.1"},
+			v31.NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1.1"},
+		},
+		Parameters: []v31.Section{
+			v31.Section{Key: "a", Text: "Parameter A for 1.1.1"},
+			v31.Section{Key: "b", Text: "Parameter B for 1.1.1"},
+		},
+		ControlOrigin: "inherited",
+	},
+	{
+		Narrative: []v31.NarrativeSection{
+			v31.NarrativeSection{Text: "Justification in narrative form for 2.1"},
+		},
+		ControlOrigin: "inherited",
+	},
+}
+
+var componentV3_1Tests = []componentV3_1Test{
+	// Check that a component with a key loads correctly
+	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "v3_1_0", "EC2"), v31.Component{
+		Name:            "Amazon Elastic Compute Cloud",
+		Key:             "EC2",
+		References:      common.GeneralReferences{{}},
+		Verifications:   common.VerificationReferences{{}, {}},
+		Satisfies:       v3_1Satisfies,
+		SchemaVersion:   semver.MustParse("3.1.0"),
+		ResponsibleRole: "AWS Staff",
+	}},
+}
+
+var v3Satisfies = []v3.Satisfies{
 	{
 		Narrative: []v3.NarrativeSection{
 			v3.NarrativeSection{Key: "a", Text: "Justification in narrative form A for CM-2"},
 			v3.NarrativeSection{Key: "b", Text: "Justification in narrative form B for CM-2"},
 		},
+
+		ControlOrigin: "shared",
 	},
 	{
 		Narrative: []v3.NarrativeSection{
@@ -44,51 +106,54 @@ var v3Satisfies = []v3.Satisfies {
 			v3.NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1"},
 		},
 		Parameters: []v3.Section{
-			v3.Section{Key: "a", Text:"Parameter A for 1.1"},
-			v3.Section{Key: "b", Text:"Parameter B for 1.1"},
+			v3.Section{Key: "a", Text: "Parameter A for 1.1"},
+			v3.Section{Key: "b", Text: "Parameter B for 1.1"},
 		},
+		ControlOrigin: "inherited",
 	},
 	{
 		Narrative: []v3.NarrativeSection{
 			v3.NarrativeSection{Key: "a", Text: "Justification in narrative form A for 1.1.1"},
 			v3.NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1.1"},
 		},
+		ControlOrigin: "inherited",
 		Parameters: []v3.Section{
-			v3.Section{Key: "a", Text:"Parameter A for 1.1.1"},
-			v3.Section{Key: "b", Text:"Parameter B for 1.1.1"},
+			v3.Section{Key: "a", Text: "Parameter A for 1.1.1"},
+			v3.Section{Key: "b", Text: "Parameter B for 1.1.1"},
 		},
 	},
 	{
 		Narrative: []v3.NarrativeSection{
 			v3.NarrativeSection{Text: "Justification in narrative form for 2.1"},
 		},
+		ControlOrigin: "inherited",
 	},
 }
 
 var componentV3Tests = []componentV3Test{
 	// Check that a component with a key loads correctly
 	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "v3_0_0", "EC2"), v3.Component{
-		Name:          "Amazon Elastic Compute Cloud",
-		Key:           "EC2",
-		References:    common.GeneralReferences{{}},
-		Verifications: common.VerificationReferences{{}, {}},
-		Satisfies:     v3Satisfies,
-		SchemaVersion: semver.MustParse("3.0.0"),
+		Name:            "Amazon Elastic Compute Cloud",
+		Key:             "EC2",
+		References:      common.GeneralReferences{{}},
+		Verifications:   common.VerificationReferences{{}, {}},
+		Satisfies:       v3Satisfies,
+		SchemaVersion:   semver.MustParse("3.0.0"),
 		ResponsibleRole: "AWS Staff",
 	}},
 	// Check that a component with no key, uses the key of its directory and loads correctly
 	{filepath.Join("..", "..", "..", "fixtures", "component_fixtures", "v3_0_0", "EC2WithKey"), v3.Component{
-		Name:          "Amazon Elastic Compute Cloud",
-		Key:           "EC2",
-		References:    common.GeneralReferences{{}},
-		Verifications: common.VerificationReferences{{}, {}},
-		Satisfies:     v3Satisfies,
-		SchemaVersion: semver.MustParse("3.0.0"),
+		Name:            "Amazon Elastic Compute Cloud",
+		Key:             "EC2",
+		References:      common.GeneralReferences{{}},
+		Verifications:   common.VerificationReferences{{}, {}},
+		Satisfies:       v3Satisfies,
+		SchemaVersion:   semver.MustParse("3.0.0"),
 		ResponsibleRole: "AWS Staff",
 	}},
 }
 
-var v2Satisfies = []v2.Satisfies {
+var v2Satisfies = []v2.Satisfies{
 	{
 		Narrative: "Justification in narrative form",
 	},
@@ -135,7 +200,7 @@ func testSet(example base.Component, actual base.Component, t *testing.T) {
 	}
 	// Check that the schema version was loaded
 	if example.GetVersion().NE(actual.GetVersion()) {
-		t.Errorf("Expected %f, Actual: %f", example.GetVersion(), actual.GetVersion())
+		t.Errorf("Expected %v, Actual: %v", example.GetVersion(), actual.GetVersion())
 	}
 	// Check that the references were loaded
 	if example.GetReferences().Len() != actual.GetReferences().Len() {
@@ -149,6 +214,8 @@ func testSet(example base.Component, actual base.Component, t *testing.T) {
 	for idx, _ := range actual.GetAllSatisfies() {
 		assert.Equal(t, (example.GetAllSatisfies())[idx].GetNarratives(), (actual.GetAllSatisfies())[idx].GetNarratives())
 		assert.Equal(t, (example.GetAllSatisfies())[idx].GetParameters(), (actual.GetAllSatisfies())[idx].GetParameters())
+		assert.Equal(t, (example.GetAllSatisfies())[idx].GetControlOrigin(), (actual.GetAllSatisfies())[idx].GetControlOrigin())
+		assert.Equal(t, (example.GetAllSatisfies())[idx].GetControlOrigins(), (actual.GetAllSatisfies())[idx].GetControlOrigins())
 	}
 	// Check the responsible role.
 	assert.Equal(t, example.GetResponsibleRole(), actual.GetResponsibleRole())
@@ -179,6 +246,10 @@ func loadValidAndTestComponent(path string, t *testing.T, example base.Component
 }
 
 func TestLoadComponent(t *testing.T) {
+	// v3_1_0 tests
+	for _, example := range componentV3_1Tests {
+		loadValidAndTestComponent(example.componentDir, t, &example.expected)
+	}
 	// V3 tests
 	for _, example := range componentV3Tests {
 		loadValidAndTestComponent(example.componentDir, t, &example.expected)

--- a/models/components/versions/parse_test.go
+++ b/models/components/versions/parse_test.go
@@ -44,8 +44,10 @@ var v3_1Satisfies = []v31.Satisfies{
 			v31.NarrativeSection{Key: "a", Text: "Justification in narrative form A for CM-2"},
 			v31.NarrativeSection{Key: "b", Text: "Justification in narrative form B for CM-2"},
 		},
-		ControlOrigin:  "shared",
-		ControlOrigins: []string{"shared", "inherited"},
+		ControlOrigin:          "shared",
+		ControlOrigins:         []string{"shared", "inherited"},
+		ImplementationStatus:   "partial",
+		ImplementationStatuses: []string{"planned", "partial"},
 	},
 	{
 		Narrative: []v31.NarrativeSection{
@@ -56,8 +58,10 @@ var v3_1Satisfies = []v31.Satisfies{
 			v31.Section{Key: "a", Text: "Parameter A for 1.1"},
 			v31.Section{Key: "b", Text: "Parameter B for 1.1"},
 		},
-		ControlOrigin:  "inherited",
-		ControlOrigins: []string{"inherited"},
+		ControlOrigin:          "inherited",
+		ControlOrigins:         []string{"inherited"},
+		ImplementationStatus:   "partial",
+		ImplementationStatuses: []string{"partial"},
 	},
 	{
 		Narrative: []v31.NarrativeSection{
@@ -68,13 +72,17 @@ var v3_1Satisfies = []v31.Satisfies{
 			v31.Section{Key: "a", Text: "Parameter A for 1.1.1"},
 			v31.Section{Key: "b", Text: "Parameter B for 1.1.1"},
 		},
-		ControlOrigin: "inherited",
+		ControlOrigin:          "inherited",
+		ImplementationStatus:   "partial",
+		ImplementationStatuses: []string{"partial"},
 	},
 	{
 		Narrative: []v31.NarrativeSection{
 			v31.NarrativeSection{Text: "Justification in narrative form for 2.1"},
 		},
-		ControlOrigin: "inherited",
+		ControlOrigin:          "inherited",
+		ImplementationStatus:   "partial",
+		ImplementationStatuses: []string{"partial"},
 	},
 }
 
@@ -97,8 +105,8 @@ var v3Satisfies = []v3.Satisfies{
 			v3.NarrativeSection{Key: "a", Text: "Justification in narrative form A for CM-2"},
 			v3.NarrativeSection{Key: "b", Text: "Justification in narrative form B for CM-2"},
 		},
-
-		ControlOrigin: "shared",
+		ControlOrigin:        "shared",
+		ImplementationStatus: "partial",
 	},
 	{
 		Narrative: []v3.NarrativeSection{
@@ -109,14 +117,16 @@ var v3Satisfies = []v3.Satisfies{
 			v3.Section{Key: "a", Text: "Parameter A for 1.1"},
 			v3.Section{Key: "b", Text: "Parameter B for 1.1"},
 		},
-		ControlOrigin: "inherited",
+		ControlOrigin:        "inherited",
+		ImplementationStatus: "partial",
 	},
 	{
 		Narrative: []v3.NarrativeSection{
 			v3.NarrativeSection{Key: "a", Text: "Justification in narrative form A for 1.1.1"},
 			v3.NarrativeSection{Key: "b", Text: "Justification in narrative form B for 1.1.1"},
 		},
-		ControlOrigin: "inherited",
+		ControlOrigin:        "inherited",
+		ImplementationStatus: "partial",
 		Parameters: []v3.Section{
 			v3.Section{Key: "a", Text: "Parameter A for 1.1.1"},
 			v3.Section{Key: "b", Text: "Parameter B for 1.1.1"},
@@ -126,7 +136,8 @@ var v3Satisfies = []v3.Satisfies{
 		Narrative: []v3.NarrativeSection{
 			v3.NarrativeSection{Text: "Justification in narrative form for 2.1"},
 		},
-		ControlOrigin: "inherited",
+		ControlOrigin:        "inherited",
+		ImplementationStatus: "partial",
 	},
 }
 
@@ -221,6 +232,7 @@ func testSet(example base.Component, actual base.Component, t *testing.T) {
 		assert.Equal(t, (example.GetAllSatisfies())[idx].GetControlOrigin(), (actual.GetAllSatisfies())[idx].GetControlOrigin())
 		assert.Equal(t, (example.GetAllSatisfies())[idx].GetControlOrigins(), (actual.GetAllSatisfies())[idx].GetControlOrigins())
 		assert.Equal(t, (example.GetAllSatisfies())[idx].GetImplementationStatus(), (actual.GetAllSatisfies())[idx].GetImplementationStatus())
+		assert.Equal(t, (example.GetAllSatisfies())[idx].GetImplementationStatuses(), (actual.GetAllSatisfies())[idx].GetImplementationStatuses())
 	}
 	// Check the responsible role.
 	assert.Equal(t, example.GetResponsibleRole(), actual.GetResponsibleRole())
@@ -252,13 +264,13 @@ func loadValidAndTestComponent(path string, t *testing.T, example base.Component
 
 func TestLoadComponent(t *testing.T) {
 	// v3_1_0 tests
-	//	for _, example := range componentV3_1Tests {
-	//		loadValidAndTestComponent(example.componentDir, t, &example.expected)
-	//	}
+	for _, example := range componentV3_1Tests {
+		loadValidAndTestComponent(example.componentDir, t, &example.expected)
+	}
 	// V3 tests
-	//	for _, example := range componentV3Tests {
-	//		loadValidAndTestComponent(example.componentDir, t, &example.expected)
-	//	}
+	for _, example := range componentV3Tests {
+		loadValidAndTestComponent(example.componentDir, t, &example.expected)
+	}
 	// V2 tests
 	for _, example := range componentV2Tests {
 		loadValidAndTestComponent(example.componentDir, t, &example.expected)

--- a/models/components/versions/parse_test.go
+++ b/models/components/versions/parse_test.go
@@ -155,7 +155,8 @@ var componentV3Tests = []componentV3Test{
 
 var v2Satisfies = []v2.Satisfies{
 	{
-		Narrative: "Justification in narrative form",
+		Narrative:             "Justification in narrative form",
+		implementation_status: "blah",
 	},
 	{
 		Narrative: "Justification in narrative form",
@@ -216,6 +217,7 @@ func testSet(example base.Component, actual base.Component, t *testing.T) {
 		assert.Equal(t, (example.GetAllSatisfies())[idx].GetParameters(), (actual.GetAllSatisfies())[idx].GetParameters())
 		assert.Equal(t, (example.GetAllSatisfies())[idx].GetControlOrigin(), (actual.GetAllSatisfies())[idx].GetControlOrigin())
 		assert.Equal(t, (example.GetAllSatisfies())[idx].GetControlOrigins(), (actual.GetAllSatisfies())[idx].GetControlOrigins())
+		assert.Equal(t, (example.GetAllSatisfies())[idx].GetImplementationStatus(), (actual.GetAllSatisfies())[idx].GetImplementationStatus())
 	}
 	// Check the responsible role.
 	assert.Equal(t, example.GetResponsibleRole(), actual.GetResponsibleRole())

--- a/models/components/versions/parse_test.go
+++ b/models/components/versions/parse_test.go
@@ -155,17 +155,20 @@ var componentV3Tests = []componentV3Test{
 
 var v2Satisfies = []v2.Satisfies{
 	{
-		Narrative:             "Justification in narrative form",
-		implementation_status: "blah",
+		Narrative:            "Justification in narrative form",
+		ImplementationStatus: "partial",
 	},
 	{
-		Narrative: "Justification in narrative form",
+		Narrative:            "Justification in narrative form",
+		ImplementationStatus: "partial",
 	},
 	{
-		Narrative: "Justification in narrative form",
+		Narrative:            "Justification in narrative form",
+		ImplementationStatus: "partial",
 	},
 	{
-		Narrative: "Justification in narrative form",
+		Narrative:            "Justification in narrative form",
+		ImplementationStatus: "partial",
 	},
 }
 
@@ -249,13 +252,13 @@ func loadValidAndTestComponent(path string, t *testing.T, example base.Component
 
 func TestLoadComponent(t *testing.T) {
 	// v3_1_0 tests
-	for _, example := range componentV3_1Tests {
-		loadValidAndTestComponent(example.componentDir, t, &example.expected)
-	}
+	//	for _, example := range componentV3_1Tests {
+	//		loadValidAndTestComponent(example.componentDir, t, &example.expected)
+	//	}
 	// V3 tests
-	for _, example := range componentV3Tests {
-		loadValidAndTestComponent(example.componentDir, t, &example.expected)
-	}
+	//	for _, example := range componentV3Tests {
+	//		loadValidAndTestComponent(example.componentDir, t, &example.expected)
+	//	}
 	// V2 tests
 	for _, example := range componentV2Tests {
 		loadValidAndTestComponent(example.componentDir, t, &example.expected)


### PR DESCRIPTION
This PR:
- Retroactively adds support for `implementation_status` to schema versions `2.0.0` and `3.0.0`. 
  - The schema already had this field but masonry did not support it.
- Introduces schema version `3.1.0` as per https://github.com/opencontrol/schemas/issues/25
  - Introduces `control_origins` and `GetControlOrigins()` interface method to Satisfies base interface.
  - Introduces `implementation_statuses` and `GetImplementationStatuses()` interface method to Satisfies base interface