### PR TITLE
The --update-vendored and --strip-vcs flags are deprecated.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This project uses [glide](https://github.com/Masterminds/glide) to manage vendor
     # (Optional) Update Dependencies
     # Install Glide first
     go get github.com/Masterminds/glide
-    glide up -s --all-dependencies --update-vendored
+    glide up --all-dependencies
     ```
 
 ### Running tests


### PR DESCRIPTION
They now work by default.

This is super minor, but I'm also seeing "Dependency golang.org/x/sys/unix failed to resolve" but as I'm not sure if it has to do with my versions of libraries, I didn't want to create an issue. The tests seem to run for me, though.