### PR TITLE
Update Linux install commands with sudo

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -35,7 +35,7 @@ In your terminal, run the following:
 ```sh
 curl -L https://github.com/opencontrol/compliance-masonry/releases/download/v1.1.2/compliance-masonry_1.1.2_linux_amd64.tar.gz -o compliance-masonry.tar.gz
 tar -xf compliance-masonry.tar.gz
-cp compliance-masonry_1.1.2_linux_amd64/compliance-masonry /usr/local/bin
+sudo cp compliance-masonry_1.1.2_linux_amd64/compliance-masonry /usr/local/bin
 ```
 
 ---


### PR DESCRIPTION
On enterprise linux distros, the /usr/local/bin/ directory is protected from non-privileged users. Need sudo to copy files into that directory.

`````
$ cp compliance-masonry_1.1.2_linux_amd64/compliance-masonry /usr/local/bin/
cp: cannot create regular file ‘/usr/local/bin/compliance-masonry’: Permission denied
`````

This patch updates the install example to use sudo.