### PR TITLE
Added openssl for git ssh support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.8-alpine
-RUN apk add --no-cache git
+RUN apk add --no-cache git openssh
 WORKDIR /go/src/github.com/opencontrol/compliance-masonry
 ADD . .
 RUN go install


### PR DESCRIPTION
My git repo is tied to ssh so this version of compliance-masonry supports that. Permits me to do:

```
# opencontrol.yaml
schema_version: "1.0.0"
name: freedonia.fd
[...]
dependencies:
  standards:
    - url: ssh+git://git@gitclone.hlsdev.local/demos/comp-masonry-freedonia-stds.git
      revision: master
  certifications:
    - url: ssh+git://git@gitclone.hlsdev.local/demos/comp-masonry-freedonia-certs.git
      revision: master
[...]
```
