### PR TITLE
Update standard v1.0.0 to include "description" field

### DIFF
--- a/commands/docs/gitbook/gitbookCertification.go
+++ b/commands/docs/gitbook/gitbookCertification.go
@@ -90,11 +90,15 @@ func (openControl *OpenControlGitBook) getControlOrigin(text string, controlOrig
 func (openControl *OpenControlGitBook) exportControl(control *ControlGitbook) (string, string) {
 	key := replaceParentheses(fmt.Sprintf("%s-%s", control.standardKey, control.controlKey))
 	text := fmt.Sprintf("#%s\n##%s\n", key, control.GetName())
+	if len(control.GetDescription()) > 0 {
+		text += "#### Description\n"
+		text += control.GetDescription()
+	}
 	selectJustifications := openControl.GetAllVerificationsWith(control.standardKey, control.controlKey)
 	// In the case that no information was found period for the standard and control
 	if len(selectJustifications) == 0 {
 		errorText := fmt.Sprintf("No information found for the combination of standard %s and control %s", control.standardKey, control.controlKey)
-		text = fmt.Sprintf("%s%s\n", text, errorText)
+		text = fmt.Sprintf("%s\n%s\n", text, errorText)
 	}
 	for _, justification := range selectJustifications {
 		component, found := openControl.GetComponent(justification.ComponentKey)

--- a/commands/docs/gitbook/gitbookCertification_test.go
+++ b/commands/docs/gitbook/gitbookCertification_test.go
@@ -31,6 +31,9 @@ var exportControlTests = []exportControlTest{
 		"NIST-800-53-CM-2.md",
 		`#NIST-800-53-CM-2
 ##Baseline Configuration
+#### Description
+'The organization develops, documents, and maintains under configuration
+control, a current baseline configuration of the information system.'
 
 #### Amazon Elastic Compute Cloud
 

--- a/fixtures/exports_fixtures/complete_export/standards/NIST-800-53-AC-2.md
+++ b/fixtures/exports_fixtures/complete_export/standards/NIST-800-53-AC-2.md
@@ -1,3 +1,32 @@
 #NIST-800-53-AC-2
 ##Account Management
+#### Description
+'The organization:
+a.	Identifies and selects the following types of information system accounts
+to support organizational missions/business functions: [Assignment:
+organization-defined information system account types];
+b.	Assigns account managers for information system accounts;
+c.	Establishes conditions for group and role membership;
+d.	Specifies authorized users of the information system, group and role
+membership, and access authorizations (i.e., privileges) and other
+attributes (as required) for each account;
+e.	Requires approvals by [Assignment: organization-defined personnel or
+roles] for requests to create information system accounts;
+f.	Creates, enables, modifies, disables, and removes information system
+accounts in accordance with [Assignment: organization-defined procedures or
+conditions];
+g.	Monitors the use of information system accounts;
+h.	Notifies account managers:
+  1.	When accounts are no longer required;
+  2.	When users are terminated or transferred; and
+  3.	When individual information system usage or need-to-know changes;
+i.	Authorizes access to the information system based on:
+  1.	A valid access authorization;
+  2.	Intended system usage; and
+  3.	Other attributes as required by the organization or associated missions/business functions;
+j.	Reviews accounts for compliance with account management requirements
+[Assignment: organization-defined frequency]; and
+k.	Establishes a process for reissuing shared/group account credentials (if
+deployed) when individuals are removed from the group.'
+
 No information found for the combination of standard NIST-800-53 and control AC-2

--- a/fixtures/exports_fixtures/complete_export/standards/NIST-800-53-AC-6.md
+++ b/fixtures/exports_fixtures/complete_export/standards/NIST-800-53-AC-6.md
@@ -1,3 +1,9 @@
 #NIST-800-53-AC-6
 ##Least Privilege
+#### Description
+'The organization employs the principle of least privilege, allowing only
+authorized accesses for users (or processes acting on behalf of users) which
+are necessary to accomplish assigned tasks in accordance with organizational
+missions and business functions.'
+
 No information found for the combination of standard NIST-800-53 and control AC-6

--- a/fixtures/exports_fixtures/complete_export/standards/NIST-800-53-CM-2.md
+++ b/fixtures/exports_fixtures/complete_export/standards/NIST-800-53-CM-2.md
@@ -1,5 +1,8 @@
 #NIST-800-53-CM-2
 ##Baseline Configuration
+#### Description
+'The organization develops, documents, and maintains under configuration
+control, a current baseline configuration of the information system.'
 
 #### Amazon Elastic Compute Cloud
 

--- a/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-1.1.1.md
+++ b/fixtures/exports_fixtures/complete_export/standards/PCI-DSS-MAY-2015-1.1.1.md
@@ -1,3 +1,4 @@
 #PCI-DSS-MAY-2015-1.1.1
 ##A formal process for approving and testing all network connections and changes to the firewall and router configurations
+
 No information found for the combination of standard PCI-DSS-MAY-2015 and control 1.1.1

--- a/fixtures/exports_fixtures/complete_export_with_markdown/standards/NIST-800-53-AC-2.md
+++ b/fixtures/exports_fixtures/complete_export_with_markdown/standards/NIST-800-53-AC-2.md
@@ -1,3 +1,4 @@
 #NIST-800-53-AC-2
 ##Account Management
+
 No information found for the combination of standard NIST-800-53 and control AC-2

--- a/fixtures/exports_fixtures/complete_export_with_markdown/standards/NIST-800-53-AC-6.md
+++ b/fixtures/exports_fixtures/complete_export_with_markdown/standards/NIST-800-53-AC-6.md
@@ -1,3 +1,4 @@
 #NIST-800-53-AC-6
 ##Least Privilege
+
 No information found for the combination of standard NIST-800-53 and control AC-6

--- a/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-1.1.1.md
+++ b/fixtures/exports_fixtures/complete_export_with_markdown/standards/PCI-DSS-MAY-2015-1.1.1.md
@@ -1,3 +1,4 @@
 #PCI-DSS-MAY-2015-1.1.1
 ##A formal process for approving and testing all network connections and changes to the firewall and router configurations
+
 No information found for the combination of standard PCI-DSS-MAY-2015 and control 1.1.1

--- a/fixtures/opencontrol_fixtures/standards/NIST-800-53.yaml
+++ b/fixtures/opencontrol_fixtures/standards/NIST-800-53.yaml
@@ -1,998 +1,3111 @@
 AC-1:
   family: AC
   name: Access Control Policy and Procedures
-AC-10:
-  family: AC
-  name: Concurrent Session Control
-AC-11:
-  family: AC
-  name: Session Lock
-AC-11 (1):
-  family: AC
-  name: Session Lock | Pattern-Hiding Displays
-AC-12:
-  family: AC
-  name: Session Termination
-AC-14:
-  family: AC
-  name: Permitted Actions Without Identification or Authentication
-AC-17:
-  family: AC
-  name: Remote Access
-AC-17 (1):
-  family: AC
-  name: Remote Access | Automated Monitoring / Control
-AC-17 (2):
-  family: AC
-  name: Remote Access | Protection of Confidentiality / Integrity Using Encryption
-AC-17 (3):
-  family: AC
-  name: Remote Access | Managed Access Control Points
-AC-17 (4):
-  family: AC
-  name: Remote Access | Privileged Commands / Access
-AC-17 (9):
-  family: AC
-  name: Remote Access | Disconnect / Disable Access
-AC-18:
-  family: AC
-  name: Wireless Access
-AC-18 (1):
-  family: AC
-  name: Wireless Access | Authentication and Encryption
-AC-19:
-  family: AC
-  name: Access Control For Mobile Devices
-AC-19 (5):
-  family: AC
-  name: Access Control For Mobile Devices | Full Device / Container-Based Encryption
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment:
+    organization-defined personnel or roles]:
+      1.	An access control policy that addresses purpose, scope, roles,
+      responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+      2.	Procedures to facilitate the
+      implementation of the access control policy and associated access
+      controls; and
+    b.	Reviews and updates the current:
+      1.	Access control policy [Assignment: organization-defined frequency]; and
+      2.	Access control procedures [Assignment: organization-defined
+      frequency].'
+
 AC-2:
   family: AC
   name: Account Management
+  description: |
+    'The organization:
+    a.	Identifies and selects the following types of information system accounts
+    to support organizational missions/business functions: [Assignment:
+    organization-defined information system account types];
+    b.	Assigns account managers for information system accounts;
+    c.	Establishes conditions for group and role membership;
+    d.	Specifies authorized users of the information system, group and role
+    membership, and access authorizations (i.e., privileges) and other
+    attributes (as required) for each account;
+    e.	Requires approvals by [Assignment: organization-defined personnel or
+    roles] for requests to create information system accounts;
+    f.	Creates, enables, modifies, disables, and removes information system
+    accounts in accordance with [Assignment: organization-defined procedures or
+    conditions];
+    g.	Monitors the use of information system accounts;
+    h.	Notifies account managers:
+      1.	When accounts are no longer required;
+      2.	When users are terminated or transferred; and
+      3.	When individual information system usage or need-to-know changes;
+    i.	Authorizes access to the information system based on:
+      1.	A valid access authorization;
+      2.	Intended system usage; and
+      3.	Other attributes as required by the organization or associated missions/business functions;
+    j.	Reviews accounts for compliance with account management requirements
+    [Assignment: organization-defined frequency]; and
+    k.	Establishes a process for reissuing shared/group account credentials (if
+    deployed) when individuals are removed from the group.'
+
 AC-2 (1):
   family: AC
   name: Account Management | Automated System Account Management
-AC-2 (10):
-  family: AC
-  name: Account Management | Shared / Group Account Credential Termination
-AC-2 (12):
-  family: AC
-  name: Account Management | Account Monitoring / Atypical Usage
+  description: |
+    'The organization employs automated mechanisms to support the management of information system accounts.'
+
 AC-2 (2):
   family: AC
   name: Account Management | Removal of Temporary / Emergency Accounts
+  description: |
+    'The information system automatically [Selection: removes; disables]
+    temporary and emergency accounts after [Assignment: organization-defined
+    time period for each type of account].'
+
 AC-2 (3):
   family: AC
   name: Account Management | Disable Inactive Accounts
+  description: |
+    'The information system automatically disables inactive accounts after
+    [Assignment: organization-defined time period].'
+
 AC-2 (4):
   family: AC
   name: Account Management | Automated Audit Actions
+  description: |
+    'The information system automatically audits account creation, modification,
+    enabling, disabling, and removal actions, and notifies [Assignment:
+    organization-defined personnel or roles].'
+
 AC-2 (5):
   family: AC
   name: Account Management | Inactivity Logout
+  description: |
+    'The organization requires that users log out when [Assignment:
+    organization-defined time-period of expected inactivity or description of
+    when to log out].'
+
 AC-2 (7):
   family: AC
   name: Account Management | Role-Based Schemes
+  description: |
+    'The organization:
+    AC-2 (7)(a)	Establishes and administers privileged user accounts in
+    accordance with a role-based access scheme that organizes allowed
+    information system access and privileges into roles;
+    AC-2 (7)(b)	Monitors privileged role assignments; and
+    AC-2 (7)(c)	Takes [Assignment: organization-defined actions] when privileged
+    role assignments are no longer appropriate.'
+
 AC-2 (9):
   family: AC
   name: Account Management | Restrictions on Use of Shared Groups / Accounts
-AC-20:
+  description: |
+    'The organization only permits the use of shared/group accounts that meet
+    [Assignment: organization-defined conditions for establishing shared/group
+    accounts].'
+
+AC-2 (10):
   family: AC
-  name: Use of External Information Systems
-AC-20 (1):
+  name: Account Management | Shared / Group Account Credential Termination
+  description: |
+    'The information system terminates shared/group account credentials when
+    members leave the group.'
+
+AC-2 (12):
   family: AC
-  name: Use of External Information Systems | Limits on Authorized Use
-AC-20 (2):
-  family: AC
-  name: Use of External Information Systems | Portable Storage Devices
-AC-21:
-  family: AC
-  name: Information Sharing
-AC-22:
-  family: AC
-  name: Publicly Accessible Content
+  name: Account Management | Account Monitoring / Atypical Usage
+  description: |
+    'The organization:
+    AC-2 (12)(a)	Monitors information system accounts for [Assignment:
+    organization-defined atypical usage]; and
+    AC-2 (12)(b)	Reports atypical usage of information system accounts to
+    [Assignment: organization-defined personnel or roles].'
+
 AC-3:
   family: AC
   name: Access Enforcement
+  description: |
+    'The information system enforces approved authorizations for logical access
+    to information and system resources in accordance with applicable access
+    control policies.'
+
 AC-4:
   family: AC
   name: Information Flow Enforcement
+  description: |
+    'The information system enforces approved authorizations for controlling the
+    flow of information within the system and between interconnected systems
+    based on [Assignment: organization-defined information flow control
+    policies].'
+
 AC-4 (21):
   family: AC
   name: Information Flow Enforcement | Physical / Logical Separation of Information
     Flows
+  description: |
+    'The information system separates information flows logically or physically
+    using [Assignment: organization-defined mechanisms and/or techniques] to
+    accomplish [Assignment: organization-defined required separations by types
+    of information].'
+
 AC-5:
   family: AC
   name: Separation of Duties
+  description: |
+    'The organization:
+    a.	Separates [Assignment: organization-defined duties of individuals];
+    b.	Documents separation of duties of individuals; and
+    c.	Defines information system access authorizations to support separation of
+    duties.'
+
 AC-6:
   family: AC
   name: Least Privilege
+  description: |
+    'The organization employs the principle of least privilege, allowing only
+    authorized accesses for users (or processes acting on behalf of users) which
+    are necessary to accomplish assigned tasks in accordance with organizational
+    missions and business functions.'
+
 AC-6 (1):
   family: AC
   name: Least Privilege | Authorize Access to Security Functions
+  description: |
+    'The organization explicitly authorizes access to [Assignment:
+    organization-defined security functions (deployed in hardware, software, and
+    firmware) and security-relevant information].'
+
+AC-6 (2):
+  family: AC
+  name: Least Privilege | Non-Privileged Access For No security Functions
+  description: |
+    'The organization requires that users of information system accounts, or
+    roles, with access to [Assignment: organization-defined security functions
+    or security-relevant information], use non-privileged accounts or roles,
+    when accessing nonsecurity functions.'
+
+AC-6 (5):
+  family: AC
+  name: Least Privilege | Privileged Accounts
+  description: |
+    'The organization restricts privileged accounts on the information system to
+    [Assignment: organization-defined personnel or roles].'
+
+AC-6 (9):
+  family: AC
+  name: Least Privilege | Auditing Use of Privileged Functions
+  description: |
+    'The information system audits the execution of privileged functions.'
+
 AC-6 (10):
   family: AC
   name: Least Privilege | Prohibit Non-privileged Users from Executing Privileged
     Functions
-AC-6 (2):
-  family: AC
-  name: Least Privilege | Non-Privileged Access For No security Functions
-AC-6 (5):
-  family: AC
-  name: Least Privilege | Privileged Accounts
-AC-6 (9):
-  family: AC
-  name: Least Privilege | Auditing Use of Privileged Functions
+  description: |
+    'The information system prevents non-privileged users from executing
+    privileged functions to include disabling, circumventing, or altering
+    implemented security safeguards/countermeasures.'
+
 AC-7:
   family: AC
   name: Unsuccessful Logon Attempts
+  description: |
+    'The information system:
+    a.	Enforces a limit of [Assignment: organization-defined number] consecutive
+    invalid logon attempts by a user during a [Assignment: organization-defined
+    time period]; and
+    b.	Automatically [Selection: locks the account/node for an [Assignment:
+    organization-defined time period]; locks the account/node until released by
+    an administrator; delays next logon prompt according to [Assignment:
+    organization-defined delay algorithm]] when the maximum number of
+    unsuccessful attempts is exceeded.'
+
 AC-8:
   family: AC
   name: System Use Notification
+  description: |
+    'The information system:
+    a.	Displays to users [Assignment: organization-defined system use
+    notification message or banner] before granting access to the system that
+    provides privacy and security notices consistent with applicable federal
+    laws, Executive Orders, directives, policies, regulations, standards, and
+    guidance and states that:
+      1.	Users are accessing a U.S. Government information system;
+      2.	Information system usage may be monitored, recorded, and subject to
+      audit;
+      3.	Unauthorized use of the information system is prohibited and subject to
+      criminal and civil penalties; and
+      4.	Use of the information system indicates consent to monitoring and
+      recording;
+    b.	Retains the notification message or banner on the screen until users
+    acknowledge the usage conditions and take explicit actions to log on to or
+    further access the information system; and
+    c.	For publicly accessible systems:
+      1.	Displays system use information [Assignment: organization-defined
+      conditions], before granting further access;
+      2.	Displays references, if any, to monitoring, recording, or auditing that
+      are consistent with privacy accommodations for such systems that generally
+      prohibit those activities; and
+      3.	Includes a description of the authorized uses of the system.'
+
+AC-10:
+  family: AC
+  name: Concurrent Session Control
+  description: |
+    'The information system limits the number of concurrent sessions for each
+    [Assignment: organization-defined account and/or account type] to
+    [Assignment: organization-defined number].'
+
+AC-11:
+  family: AC
+  name: Session Lock
+  description: |
+    'The information system:
+    a.	Prevents further access to the system by initiating a session lock after
+    [Assignment: organization-defined time period] of inactivity or upon
+    receiving a request from a user; and
+    b.	Retains the session lock until the user reestablishes access using
+    established identification and authentication procedures.'
+
+AC-11 (1):
+  family: AC
+  name: Session Lock | Pattern-Hiding Displays
+  description: |
+    'The information system conceals, via the session lock, information
+    previously visible on the display with a publicly viewable image.'
+
+AC-12:
+  family: AC
+  name: Session Termination
+  description: |
+    'The information system automatically terminates a user session after
+    [Assignment: organization-defined conditions or trigger events requiring
+    session disconnect].'
+
+AC-14:
+  family: AC
+  name: Permitted Actions Without Identification or Authentication
+  description: |
+    'The organization:
+    a.	Identifies [Assignment: organization-defined user actions] that can be
+    performed on the information system without identification or authentication
+    consistent with organizational missions/business functions; and
+    b.	Documents and provides supporting rationale in the security plan for the
+    information system, user actions not requiring identification or
+    authentication.'
+
+AC-17:
+  family: AC
+  name: Remote Access
+  description: |
+    'The organization:
+    a.	Establishes and documents usage restrictions, configuration/connection
+    requirements, and implementation guidance for each type of remote access
+    allowed; and
+    b.	Authorizes remote access to the information system prior to allowing such
+    connections.'
+
+AC-17 (1):
+  family: AC
+  name: Remote Access | Automated Monitoring / Control
+  description: |
+    'The information system monitors and controls remote access methods.'
+
+AC-17 (2):
+  family: AC
+  name: Remote Access | Protection of Confidentiality / Integrity Using Encryption
+  description: |
+    'The information system implements cryptographic mechanisms to protect the
+    confidentiality and integrity of remote access sessions.'
+
+AC-17 (3):
+  family: AC
+  name: Remote Access | Managed Access Control Points
+  description: |
+    'The information system routes all remote accesses through [Assignment:
+    organization-defined number] managed network access control points.'
+
+AC-17 (4):
+  family: AC
+  name: Remote Access | Privileged Commands / Access
+  description: |
+    'The organization:
+    AC-17 (4)(a)	Authorizes the execution of privileged commands and access to
+    security-relevant information via remote access only for [Assignment:
+    organization-defined needs]; and
+    AC-17 (4)(b)	Documents the rationale for such access in the security plan
+    for the information system.'
+
+AC-17 (9):
+  family: AC
+  name: Remote Access | Disconnect / Disable Access
+  description: |
+    'The organization provides the capability to expeditiously disconnect or
+    disable remote access to the information system within [Assignment:
+    organization-defined time period].'
+
+AC-18:
+  family: AC
+  name: Wireless Access
+  description: |
+    'The organization:
+    a.	Establishes usage restrictions, configuration/connection requirements,
+    and implementation guidance for wireless access; and
+    b.	Authorizes wireless access to the information system prior to allowing
+    such connections.'
+
+AC-18 (1):
+  family: AC
+  name: Wireless Access | Authentication and Encryption
+  description: |
+    'The information system protects wireless access to the system using
+    authentication of [Selection (one or more): users; devices] and encryption.'
+
+AC-19:
+  family: AC
+  name: Access Control For Mobile Devices
+  description: |
+    'The organization:
+    a.	Establishes usage restrictions, configuration requirements, connection
+    requirements, and implementation guidance for organization-controlled mobile
+    devices; and
+    b.	Authorizes the connection of mobile devices to organizational information
+    systems.'
+
+AC-19 (5):
+  family: AC
+  name: Access Control For Mobile Devices | Full Device / Container-Based Encryption
+  description: |
+    'The organization employs [Selection: full-device encryption; container
+    encryption] to protect the confidentiality and integrity of information on
+    [Assignment: organization-defined mobile devices].'
+
+AC-20:
+  family: AC
+  name: Use of External Information Systems
+  description: |
+    'The organization establishes terms and conditions, consistent with any
+    trust relationships established with other organizations owning, operating,
+    and/or maintaining external information systems, allowing authorized
+    individuals to:
+    a.	Access the information system from external information systems; and
+    b.	Process, store, or transmit organization-controlled information using
+    external information systems.'
+
+AC-20 (1):
+  family: AC
+  name: Use of External Information Systems | Limits on Authorized Use
+  description: |
+    'The organization permits authorized individuals to use an external
+    information system to access the information system or to process, store, or
+    transmit organization-controlled information only when the organization:
+    AC-20 (1)(a)	Verifies the implementation of required security controls on
+    the external system as specified in the organization's information security
+    policy and security plan; or
+    AC-20 (1)(b)	Retains approved information system connection or processing
+    agreements with the organizational entity hosting the external information
+    system.'
+
+AC-20 (2):
+  family: AC
+  name: Use of External Information Systems | Portable Storage Devices
+  description: |
+    'The organization [Selection: restricts; prohibits] the use of
+    organization-controlled portable storage devices by authorized individuals
+    on external information systems.'
+
+AC-21:
+  family: AC
+  name: Information Sharing
+  description: |
+    'The organization:
+    a.	Facilitates information sharing by enabling authorized users to determine
+    whether access authorizations assigned to the sharing partner match the
+    access restrictions on the information for [Assignment: organization-defined
+    information sharing circumstances where user discretion is required]; and
+    b.	Employs [Assignment: organization-defined automated mechanisms or manual
+    processes] to assist users in making information sharing/collaboration
+    decisions.'
+
+AC-22:
+  family: AC
+  name: Publicly Accessible Content
+  description: |
+    'The organization:
+    a.	Designates individuals authorized to post information onto a publicly
+    accessible information system;
+    b.	Trains authorized individuals to ensure that publicly accessible
+    information does not contain nonpublic information;
+    c.	Reviews the proposed content of information prior to posting onto the
+    publicly accessible information system to ensure that nonpublic information
+    is not included; and
+    d.	Reviews the content on the publicly accessible information system for
+    nonpublic information [Assignment: organization-defined frequency] and
+    removes such information, if discovered.'
+
 AT-1:
   family: AT
   name: Security Awareness and Training Policy and Procedures
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment:
+    organization-defined personnel or roles]:
+      1.	A security awareness and training policy that addresses purpose, scope,
+      roles, responsibilities, management commitment, coordination among
+      organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the security awareness
+      and training policy and associated security awareness and training
+      controls; and
+    b.	Reviews and updates the current:
+      1.	Security awareness and training policy [Assignment:
+      organization-defined frequency]; and
+      2.	Security awareness and training procedures [Assignment:
+      organization-defined frequency].'
+
 AT-2:
   family: AT
   name: Security Awareness Training
+  description: |
+    'The organization provides basic security awareness training to information
+    system users (including managers, senior executives, and contractors):
+    a.	As part of initial training for new users;
+    b.	When required by information system changes; and
+    c.	[Assignment: organization-defined frequency] thereafter.'
+
 AT-2 (2):
   family: AT
   name: Security Awareness | Insider Threat
+  description: |
+    'The organization includes security awareness training on recognizing and
+    reporting potential indicators of insider threat.'
+
 AT-3:
   family: AT
   name: Role-Based Security Training
+  description: |
+    'The organization provides role-based security training to personnel with
+    assigned security roles and responsibilities:
+    a.	Before authorizing access to the information system or performing
+    assigned duties;
+    b.	When required by information system changes; and
+    c.	[Assignment: organization-defined frequency] thereafter.'
+
 AT-4:
   family: AT
   name: Security Training Records
+  description: |
+    'The organization:
+    a.	Documents and monitors individual information system security training
+    activities including basic security awareness training and specific
+    information system security training; and
+    b.	Retains individual training records for [Assignment: organization-defined
+    time period].'
+
 AU-1:
   family: AU
   name: Audit and Accountability Policy and Procedures
-AU-11:
-  family: AU
-  name: Audit Record Retention
-AU-12:
-  family: AU
-  name: Audit Generation
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment:
+    organization-defined personnel or roles]:
+      1.	An audit and accountability policy that addresses purpose, scope,
+      roles, responsibilities, management commitment, coordination among
+      organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the audit and
+      accountability policy and associated audit and accountability controls;
+      and
+    b.	Reviews and updates the current:
+      1.	Audit and accountability policy [Assignment: organization-defined
+      frequency]; and
+      2.	Audit and accountability procedures [Assignment: organization-defined
+      frequency].'
+
 AU-2:
   family: AU
   name: Audit Events
+  description: |
+    'The organization:
+    a.	Determines that the information system is capable of auditing the
+    following events: [Assignment: organization-defined auditable events];
+    b.	Coordinates the security audit function with other organizational
+    entities requiring audit-related information to enhance mutual support and
+    to help guide the selection of auditable events;
+    c.	Provides a rationale for why the auditable events are deemed to be
+    adequate to support after-the-fact investigations of security incidents; and
+    d.	Determines that the following events are to be audited within the
+    information system: [Assignment: organization-defined audited events (the
+    subset of the auditable events defined in AU-2 a.) along with the frequency
+    of (or situation requiring) auditing for each identified event].'
+
 AU-2 (3):
   family: AU
   name: Audit Events | Reviews and Updates
+  description: |
+    'The organization reviews and updates the audited events [Assignment: organization-defined frequency].'
+
 AU-3:
   family: AU
   name: Content of Audit Records
+  description: |
+    'The information system generates audit records containing information that
+    establishes what type of event occurred, when the event occurred, where the
+    event occurred, the source of the event, the outcome of the event, and the
+    identity of any individuals or subjects associated with the event.'
+
 AU-3 (1):
   family: AU
   name: Content of Audit Records | Additional Audit Information
+  description: |
+    'The information system generates audit records containing the following
+    additional information: [Assignment: organization-defined additional, more
+    detailed information].'
+
 AU-4:
   family: AU
   name: Audit Storage Capacity
+  description: |
+    'The organization allocates audit record storage capacity in accordance with
+    [Assignment: organization-defined audit record storage requirements].'
+
 AU-5:
   family: AU
   name: Response to Audit Processing Failures
+  description: |
+    'The information system:
+    a.	Alerts [Assignment: organization-defined personnel or roles] in the event
+    of an audit processing failure; and
+    b.	Takes the following additional actions: [Assignment: organization-defined
+    actions to be taken (e.g., shut down information system, overwrite oldest
+    audit records, stop generating audit records)].'
+
 AU-6:
   family: AU
   name: Audit Review, Analysis, and Reporting
+  description: |
+    'The organization:
+    a.	Reviews and analyzes information system audit records [Assignment:
+    organization-defined frequency] for indications of [Assignment:
+    organization-defined inappropriate or unusual activity]; and
+    b.	Reports findings to [Assignment: organization-defined personnel or
+    roles].'
+
 AU-6 (1):
   family: AU
   name: Audit Review, Analysis, and Reporting | Process Integration
+  description: |
+    'The organization employs automated mechanisms to integrate audit review,
+    analysis, and reporting processes to support organizational processes for
+    investigation and response to suspicious activities.'
+
 AU-6 (3):
   family: AU
   name: Audit Review, Analysis, and Reporting | Correlate Audit Repositories
+  description: |
+    'The organization analyzes and correlates audit records across different
+    repositories to gain organization-wide situational awareness.'
+
 AU-7:
   family: AU
   name: Audit Reduction and Report Generation
+  description: |
+    'The information system provides an audit reduction and report generation
+    capability that:
+    a.	Supports on-demand audit review, analysis, and reporting requirements and
+    after-the-fact investigations of security incidents; and
+    b.	Does not alter the original content or time ordering of audit records.'
+
 AU-7 (1):
   family: AU
   name: Audit Reduction and Report Generation | Automatic Processing
+  description: |
+    'The information system provides the capability to process audit records for
+    events of interest based on [Assignment: organization-defined audit fields
+    within audit records].'
+
 AU-8:
   family: AU
   name: Time Stamps
+  description: |
+    'The information system:
+    a.	Uses internal system clocks to generate time stamps for audit records;
+    and
+    b.	Records time stamps for audit records that can be mapped to Coordinated
+    Universal Time (UTC) or Greenwich Mean Time (GMT) and meets [Assignment:
+    organization-defined granularity of time measurement].'
+
 AU-8 (1):
   family: AU
   name: Time Stamps | Synchronization With Authoritative Time Source
+  description: |
+    'The information system:
+    AU-8 (1)(a)	Compares the internal information system clocks [Assignment:
+    organization-defined frequency] with [Assignment: organization-defined
+    authoritative time source]; and
+    AU-8 (1)(b) Synchronizes the internal system clocks to the authoritative
+    time source when the time difference is greater than [Assignment:
+    organization-defined time period].'
+
 AU-9:
   family: AU
   name: Protection of Audit Information
+  description: |
+    'The information system protects audit information and audit tools from
+    unauthorized access, modification, and deletion.'
+
 AU-9 (2):
   family: AU
   name: Protection of Audit Information | Audit Backup on Separate Physical Systems
     / Components
+  description: |
+    'The information system backs up audit records [Assignment:
+    organization-defined frequency] onto a physically different system or system
+    component than the system or component being audited.'
+
 AU-9 (4):
   family: AU
   name: Protection of Audit Information | Access by Subset of Privileged Users
+  description: |
+    'The organization authorizes access to management of audit functionality to
+    only [Assignment: organization-defined subset of privileged users].'
+
+AU-11:
+  family: AU
+  name: Audit Record Retention
+  description: |
+    'The organization retains audit records for [Assignment:
+    organization-defined time period consistent with records retention policy]
+    to provide support for after-the-fact investigations of security incidents
+    and to meet regulatory and organizational information retention
+    requirements.'
+
+AU-12:
+  family: AU
+  name: Audit Generation
+  description: |
+    'The information system:
+    a.	Provides audit record generation capability for the auditable events
+    defined in AU-2 a. at [Assignment: organization-defined information system
+    components];
+    b.	Allows [Assignment: organization-defined personnel or roles] to select
+    which auditable events are to be audited by specific components of the
+    information system; and
+    c.	Generates audit records for the events defined in AU-2 d. with the
+    content defined in AU-3.'
+
 CA-1:
   family: CA
   name: Security Assessment and Authorization Policies and Procedures
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment:
+    organization-defined personnel or roles]:
+      1.	A security assessment and authorization policy that addresses purpose,
+      scope, roles, responsibilities, management commitment, coordination among
+      organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the security assessment
+      and authorization policy and associated security assessment and
+      authorization controls; and
+    b.	Reviews and updates the current:
+      1.	Security assessment and authorization policy [Assignment:
+      organization-defined frequency]; and
+      2.	Security assessment and authorization procedures [Assignment:
+      organization-defined frequency].'
+
 CA-2:
   family: CA
   name: Security Assessments
+  description: |
+    'The organization:
+    a.	Develops a security assessment plan that describes the scope of the
+    assessment including:
+      1.	Security controls and control enhancements under assessment;
+      2.	Assessment procedures to be used to determine security control
+      effectiveness; and
+      3.	Assessment environment, assessment team, and assessment roles and
+      responsibilities;
+    b.	Assesses the security controls in the information system and its
+    environment of operation [Assignment: organization-defined frequency] to
+    determine the extent to which the controls are implemented correctly,
+    operating as intended, and producing the desired outcome with respect to
+    meeting established security requirements;
+    c.	Produces a security assessment report that documents the results of the
+    assessment; and
+    d.	Provides the results of the security control assessment to [Assignment:
+    organization-defined individuals or roles].'
+
 CA-2 (1):
   family: CA
   name: Security Assessments | Independent Assessors
+  description: |
+    'The organization employs assessors or assessment teams with [Assignment:
+    organization-defined level of independence] to conduct security control
+    assessments.'
+
 CA-2 (2):
   family: CA
   name: Security Assessments | Specialized Assessments
+  description: |
+    'The organization includes as part of security control assessments,
+    [Assignment: organization-defined frequency], [Selection: announced;
+    unannounced], [Selection (one or more): in-depth monitoring; vulnerability
+    scanning; malicious user testing; insider threat assessment;
+    performance/load testing; [Assignment: organization-defined other forms of
+    security assessment]].'
+
 CA-2 (3):
   family: CA
   name: Security Assessments | External Organizations
+  description: |
+    'The organization accepts the results of an assessment of [Assignment:
+    organization-defined information system] performed by [Assignment:
+    organization-defined external organization] when the assessment meets
+    [Assignment: organization-defined requirements].'
+
 CA-3:
   family: CA
   name: System Interconnections
+  description: |
+    'The organization:
+    a.	Authorizes connections from the information system to other information
+    systems through the use of Interconnection Security Agreements;
+    b.	Documents, for each interconnection, the interface characteristics,
+    security requirements, and the nature of the information communicated; and
+    c.	Reviews and updates Interconnection Security Agreements [Assignment:
+    organization-defined frequency].'
+
 CA-3 (3):
   family: CA
   name: System Interconnections | Unclassified Non-National Security System Connections
+  description: |
+    'The organization prohibits the direct connection of an [Assignment:
+    organization-defined unclassified, non-national security system] to an
+    external network without the use of [Assignment; organization-defined
+    boundary protection device].'
+
 CA-3 (5):
   family: CA
   name: System Interconnections | Restrictions on External Network Connections
+  description: |
+    'The organization employs [Selection: allow-all, deny-by-exception;
+    deny-all, permit-by-exception] policy for allowing [Assignment:
+    organization-defined information systems] to connect to external information
+    systems.'
+
 CA-5:
   family: CA
   name: Plan of Action and Milestones
+  description: |
+    'The organization:
+    a.	Develops a plan of action and milestones for the information system to
+    document the organization''s planned remedial actions to correct weaknesses
+    or deficiencies noted during the assessment of the security controls and to
+    reduce or eliminate known vulnerabilities in the system; and
+    b.	Updates existing plan of action and milestones [Assignment:
+    organization-defined frequency] based on the findings from security controls
+    assessments, security impact analyses, and continuous monitoring
+    activities.'
+
 CA-6:
   family: CA
   name: Security Authorization
+  description: |
+    'The organization:
+    a.	Assigns a senior-level executive or manager as the authorizing official
+    for the information system;
+    b.	Ensures that the authorizing official authorizes the information system
+    for processing before commencing operations; and
+    c.	Updates the security authorization [Assignment: organization-defined
+    frequency].'
+
 CA-7:
   family: CA
   name: Continuous Monitoring
+  description: |
+    'The organization develops a continuous monitoring strategy and implements a
+    continuous monitoring program that includes:
+    a.	Establishment of [Assignment: organization-defined metrics] to be
+    monitored;
+    b.	Establishment of [Assignment: organization-defined frequencies] for
+    monitoring and [Assignment: organization-defined frequencies] for
+    assessments supporting such monitoring;
+    c.	Ongoing security control assessments in accordance with the
+    organizational continuous monitoring strategy;
+    d.	Ongoing security status monitoring of organization-defined metrics in
+    accordance with the organizational continuous monitoring strategy;
+    e.	Correlation and analysis of security-related information generated by
+    assessments and monitoring;
+    f.	Response actions to address results of the analysis of security-related
+    information; and
+    g.	Reporting the security status of organization and the information system
+    to [Assignment: organization-defined personnel or roles] [Assignment:
+    organization-defined frequency].'
+
 CA-7 (1):
   family: CA
   name: Continuous Monitoring | Independent Assessment
+  description: |
+    'The organization employs assessors or assessment teams with [Assignment:
+    organization-defined level of independence] to monitor the security controls
+    in the information system on an ongoing basis.'
+
 CA-8:
   family: CA
   name: Penetration Testing
+  description: |
+    'The organization conducts penetration testing [Assignment:
+    organization-defined frequency] on [Assignment: organization-defined
+    information systems or system components].'
+
 CA-8 (1):
   family: CA
   name: Penetration Testing | Independent Penetration Agent or Team
+  description: |
+    'The organization employs an independent penetration agent or penetration
+    team to perform penetration testing on the information system or system
+    components.'
+
 CA-9:
   family: CA
   name: Internal System Connections
+  description: |
+    'The organization:
+    a.	Authorizes internal connections of [Assignment: organization-defined
+    information system components or classes of components] to the information
+    system; and
+    b.	Documents, for each internal connection, the interface characteristics,
+    security requirements, and the nature of the information communicated.'
+
 CM-1:
   family: CM
   name: Configuration Management Policy and Procedures
-CM-10:
-  family: CM
-  name: Software Usage Restrictions
-CM-10 (1):
-  family: CM
-  name: Software Usage Restrictions | Open Source Software
-CM-11:
-  family: CM
-  name: User-Installed Software
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment:
+    organization-defined personnel or roles]:
+      1.	A configuration management policy that addresses purpose, scope, roles,
+      responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the configuration
+      management policy and associated configuration management controls; and
+    b.	Reviews and updates the current:
+      1.	Configuration management policy [Assignment: organization-defined
+      frequency]; and
+      2.	Configuration management procedures [Assignment: organization-defined
+      frequency].'
+
 CM-2:
   family: CM
   name: Baseline Configuration
+  description: |
+    'The organization develops, documents, and maintains under configuration
+    control, a current baseline configuration of the information system.'
+
 CM-2 (1):
   family: CM
   name: Baseline Configuration | Reviews and Updates
+  description: |
+    'The organization reviews and updates the baseline configuration of the
+    information system:
+    CM-2 (1)(a)	[Assignment: organization-defined frequency];
+    CM-2 (1)(b)	When required due to [Assignment organization-defined
+    circumstances]; and
+    CM-2 (1)(c)	As an integral part of information system component
+    installations and upgrades.'
+
+CM-2(2):
+  family: CM
+  name: Baseline Configuration | Automation Support For Accuracy / Currency
+  description: |
+    'The organization employs automated mechanisms to maintain an up-to-date,
+    complete, accurate, and readily available baseline configuration of the
+    information system.'
+
 CM-2 (3):
   family: CM
   name: Baseline Configuration | Retention of Previous Configurations
+  description: |
+    'The organization retains [Assignment: organization-defined previous
+    versions of baseline configurations of the information system] to support
+    rollback.'
+
 CM-2 (7):
   family: CM
   name: Baseline Configuration | Configure Systems, Components, or Devices for High-Risk
     Areas
-CM-2(2):
-  family: CM
-  name: Baseline Configuration | Automation Support For Accuracy / Currency
+  description: |
+    'The organization:
+    CM-2 (7)(a)	Issues [Assignment: organization-defined information systems,
+    system components, or devices] with [Assignment: organization-defined
+    configurations] to individuals traveling to locations that the organization
+    deems to be of significant risk; and
+    CM-2 (7)(b)	Applies [Assignment: organization-defined security safeguards]
+    to the devices when the individuals return.'
+
 CM-3:
   family: CM
   name: Configuration Change Control
+  description: |
+    'The organization:
+    a.	Determines the types of changes to the information system that are
+    configuration-controlled;
+    b.	Reviews proposed configuration-controlled changes to the information
+    system and approves or disapproves such changes with explicit consideration
+    for security impact analyses;
+    c.	Documents configuration change decisions associated with the information
+    system;
+    d.	Implements approved configuration-controlled changes to the information
+    system;
+    e.	Retains records of configuration-controlled changes to the information
+    system for [Assignment: organization-defined time period];
+    f.	Audits and reviews activities associated with configuration-controlled
+    changes to the information system; and
+    g.	Coordinates and provides oversight for configuration change control
+    activities through [Assignment: organization-defined configuration change
+    control element (e.g., committee, board)] that convenes [Selection (one or
+    more): [Assignment: organization-defined frequency]; [Assignment:
+    organization-defined configuration change conditions]].'
+
 CM-4:
   family: CM
   name: Security Impact Analysis
+  description: |
+    'The organization analyzes changes to the information system to determine
+    potential security impacts prior to change implementation.'
+
 CM-5:
   family: CM
   name: Access Restrictions For Change
+  description: |
+    'The organization defines, documents, approves, and enforces physical and
+    logical access restrictions associated with changes to the information
+    system.'
+
 CM-5 (1):
   family: CM
   name: Access Restrictions For Change | Automated Access Enforcement / Auditing
+  description: |
+    'The information system enforces access restrictions and supports auditing
+    of the enforcement actions.'
+
 CM-5 (3):
   family: CM
   name: Access Restrictions For Change | Signed Components
+  description: |
+    'The information system prevents the installation of [Assignment:
+    organization-defined software and firmware components] without verification
+    that the component has been digitally signed using a certificate that is
+    recognized and approved by the organization.'
+
 CM-5 (5):
   family: CM
   name: Access Restrictions For Change | Limit Production / Operational Privileges
+  description: |
+    'The organization:
+    CM-5 (5)(a)	Limits privileges to change information system components and system-related information within a production or operational environment; and
+    CM-5 (5)(b) Reviews and reevaluates privileges [Assignment: organization-defined frequency].'
 CM-6:
   family: CM
   name: Configuration Settings
+  description: |
+    'The organization:
+    a.	Establishes and documents configuration settings for information technology products employed within the information system using [Assignment: organization-defined security configuration checklists] that reflect the most restrictive mode consistent with operational requirements;
+    b.	Implements the configuration settings;
+    c.	Identifies, documents, and approves any deviations from established configuration settings for [Assignment: organization-defined information system components] based on [Assignment: organization-defined operational requirements]; and
+    d.	Monitors and controls changes to the configuration settings in accordance with organizational policies and procedures.'
+
 CM-6 (1):
   family: CM
   name: Configuration Settings | Automated essential Management / Application / Verification
+  description: |
+    'The organization employs automated mechanisms to centrally manage, apply,
+    and verify configuration settings for [Assignment: organization-defined
+    information system components].'
+
 CM-7:
   family: CM
   name: Least Functionality
+  description: |
+    'The organization:
+    a.	Configures the information system to provide only essential capabilities; and
+    b.	Prohibits or restricts the use of the following functions, ports, protocols, and/or services: [Assignment: organization-defined prohibited or restricted functions, ports, protocols, and/or services].'
+
 CM-7 (1):
   family: CM
   name: Least Functionality | Periodic Review
+  description: |
+    'The organization:
+    CM-7 (1)(a)	Reviews the information system [Assignment: organization-defined frequency] to identify unnecessary and/or nonsecure functions, ports, protocols, and services; and
+    CM-7 (1)(b)	Disables [Assignment: organization-defined functions, ports, protocols, and services within the information system deemed to be unnecessary and/or nonsecure].'
+
 CM-7 (2):
   family: CM
   name: Least Functionality | Prevent Program Execution
+  description: |
+    'The information system prevents program execution in accordance with
+    [Selection (one or more): [Assignment: organization-defined policies
+    regarding software program usage and restrictions]; rules authorizing the
+    terms and conditions of software program usage].'
+
 CM-7 (5):
   family: CM
   name: Least Functionality | Authorized Software / Whitelisting
+  description: |
+    'The organization:
+    CM-7 (5)(a)	Identifies [Assignment: organization-defined software programs authorized to execute on the information system];
+    CM-7 (5)(b)	Employs a deny-all, permit-by-exception policy to allow the execution of authorized software programs on the information system; and
+    CM-7 (5)(c)	Reviews and updates the list of authorized software programs [Assignment: organization-defined frequency].'
+
 CM-8:
   family: CM
   name: Information System Component Inventory
+  description: |
+    'The organization:
+    a.	Develops and documents an inventory of information system components that:
+      1.	Accurately reflects the current information system;
+      2.	Includes all components within the authorization boundary of the information system;
+      3.	Is at the level of granularity deemed necessary for tracking and reporting; and
+      4.	Includes [Assignment: organization-defined information deemed necessary to achieve effective information system component accountability]; and
+    b.	Reviews and updates the information system component inventory [Assignment: organization-defined frequency].'
+
 CM-8 (1):
   family: CM
   name: Information System Component Inventory | Updates During Installations / Removals
+  description: |
+    'The organization updates the inventory of information system components as
+    an integral part of component installations, removals, and information
+    system updates.'
+
 CM-8 (3):
   family: CM
   name: Information System Component Inventory | Automated Unauthorized Component
     Detection
+  description: |
+    'The organization:
+    CM-8 (3)(a)	Employs automated mechanisms [Assignment: organization-defined frequency] to detect the presence of unauthorized hardware, software, and firmware components within the information system; and
+    CM-8 (3)(b)	Takes the following actions when unauthorized components are detected: [Selection (one or more): disables network access by such components; isolates the components; notifies [Assignment: organization-defined personnel or roles]].'
+
 CM-8 (5):
   family: CM
   name: Information System Component Inventory | No Duplicate Accounting of Components
+  description: |
+    'The organization verifies that all components within the authorization
+    boundary of the information system are not duplicated in other information
+    system component inventories.'
+
 CM-9:
   family: CM
   name: Configuration Management Plan
+  description: |
+    'The organization develops, documents, and implements a configuration management plan for the information system that:
+    a.	Addresses roles, responsibilities, and configuration management processes and procedures;
+    b.	Establishes a process for identifying configuration items throughout the system development life cycle and for managing the configuration of the configuration items;
+    c.	Defines the configuration items for the information system and places the configuration items under configuration management; and
+    d.	Protects the configuration management plan from unauthorized disclosure and modification.'
+
+CM-10:
+  family: CM
+  name: Software Usage Restrictions
+  description: |
+    'The organization:
+    a.	Uses software and associated documentation in accordance with contract agreements and copyright laws;
+    b.	Tracks the use of software and associated documentation protected by quantity licenses to control copying and distribution; and
+    c.	Controls and documents the use of peer-to-peer file sharing technology to ensure that this capability is not used for the unauthorized distribution, display, performance, or reproduction of copyrighted work.'
+
+CM-10 (1):
+  family: CM
+  name: Software Usage Restrictions | Open Source Software
+  description: |
+    'The organization establishes the following restrictions on the use of open
+    source software: [Assignment: organization-defined restrictions].'
+
+CM-11:
+  family: CM
+  name: User-Installed Software
+  description: |
+    'The organization:
+    a.	Establishes [Assignment: organization-defined policies] governing the installation of software by users;
+    b.	Enforces software installation policies through [Assignment: organization-defined methods]; and
+    c.	Monitors policy compliance at [Assignment: organization-defined frequency].'
+
 CP-1:
   family: CP
   name: Contingency Planning Policy and Procedures
-CP-10:
-  family: CP
-  name: Information System Recovery and Reconstitution
-CP-10 (2):
-  family: CP
-  name: Information System Recovery and Reconstitution | Transaction Recovery
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	A contingency planning policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the contingency planning policy and associated contingency planning controls; and
+    b.	Reviews and updates the current:
+      1.	Contingency planning policy [Assignment: organization-defined frequency]; and
+      2.	Contingency planning procedures [Assignment: organization-defined frequency].'
+
 CP-2:
   family: CP
   name: Contingency Plan
+  description: |
+    'The organization:
+    a.	Develops a contingency plan for the information system that:
+      1.	Identifies essential missions and business functions and associated contingency requirements;
+      2.	Provides recovery objectives, restoration priorities, and metrics;
+      3.	Addresses contingency roles, responsibilities, assigned individuals with contact information;
+      4.	Addresses maintaining essential missions and business functions despite an information system disruption, compromise, or failure;
+      5.	Addresses eventual, full information system restoration without deterioration of the security safeguards originally planned and implemented; and
+      6.	Is reviewed and approved by [Assignment: organization-defined personnel or roles];
+    b.	Distributes copies of the contingency plan to [Assignment: organization-defined key contingency personnel (identified by name and/or by role) and organizational elements];
+    c.	Coordinates contingency planning activities with incident handling activities;
+    d.	Reviews the contingency plan for the information system [Assignment: organization-defined frequency];
+    e.	Updates the contingency plan to address changes to the organization, information system, or environment of operation and problems encountered during contingency plan implementation, execution, or testing;
+    f.	Communicates contingency plan changes to [Assignment: organization-defined key contingency personnel (identified by name and/or by role) and organizational elements]; and
+    g.	Protects the contingency plan from unauthorized disclosure and modification.'
+
 CP-2 (1):
   family: CP
   name: Contingency Plan | Coordinate With Related Plans
+  description: |
+    'The organization coordinates contingency plan development with
+    organizational elements responsible for related plans.'
+
 CP-2 (2):
   family: CP
   name: Contingency Plan | Capacity Planning
+  description: |
+    'The organization conducts capacity planning so that necessary capacity for
+    information processing, telecommunications, and environmental support exists
+    during contingency operations.'
+
 CP-2 (3):
   family: CP
   name: Contingency Plan | Resume Essential Missions / Business Functions
+  description: |
+    'The organization plans for the resumption of essential missions and
+    business functions within [Assignment: organization-defined time period] of
+    contingency plan activation.'
+
 CP-2 (8):
   family: CP
   name: Contingency Plan | Identify Critical Assets
+  description: |
+    'The organization identifies critical information system assets supporting
+    essential missions and business functions.'
+
 CP-3:
   family: CP
   name: Contingency Training
+  description: |
+    'The organization provides contingency training to information system users consistent with assigned roles and responsibilities:
+    a.	Within [Assignment: organization-defined time period] of assuming a contingency role or responsibility;
+    b.	When required by information system changes; and
+    c.	[Assignment: organization-defined frequency] thereafter.'
+
 CP-4:
   family: CP
   name: Contingency Plan Testing
+  description: |
+    'The organization:
+    a.	Tests the contingency plan for the information system [Assignment: organization-defined frequency] using [Assignment: organization-defined tests] to determine the effectiveness of the plan and the organizational readiness to execute the plan;
+    b.	Reviews the contingency plan test results; and
+    c.	Initiates corrective actions, if needed.'
+
 CP-4 (1):
   family: CP
   name: Contingency Plan Testing | Coordinate With Related Plans
+  description: |
+    'The organization coordinates contingency plan testing with organizational
+    elements responsible for related plans.'
+
 CP-6:
   family: CP
   name: Alternate Storage Site
+  description: |
+    'The organization:
+    a.	Establishes an alternate storage site including necessary agreements to permit the storage and retrieval of information system backup information; and
+    b.	Ensures that the alternate storage site provides information security safeguards equivalent to that of the primary site.'
+
 CP-6 (1):
   family: CP
   name: Alternate Storage Site | Separation From Primary Site
+  description: |
+    'The organization identifies an alternate storage site that is separated
+    from the primary storage site to reduce susceptibility to the same threats.'
+
 CP-6 (3):
   family: CP
   name: Alternate Storage Site | Accessibility
+  description: |
+    'The organization identifies potential accessibility problems to the
+    alternate storage site in the event of an area-wide disruption or disaster
+    and outlines explicit mitigation actions.'
+
 CP-7:
   family: CP
   name: Alternate Processing Site
+  description: |
+    'The organization:
+    a.	Establishes an alternate processing site including necessary agreements to permit the transfer and resumption of [Assignment: organization-defined information system operations] for essential missions/business functions within [Assignment: organization-defined time period consistent with recovery time and recovery point objectives] when the primary processing capabilities are unavailable;
+    b.	Ensures that equipment and supplies required to transfer and resume operations are available at the alternate processing site or contracts are in place to support delivery to the site within the organization-defined time period for transfer/resumption; and
+    c.	Ensures that the alternate processing site provides information security safeguards equivalent to those of the primary site.'
+
 CP-7 (1):
   family: CP
   name: Alternate Processing Site | Separation From Primary Site
+  description: |
+    'The organization identifies an alternate processing site that is separated
+    from the primary processing site to reduce susceptibility to the same
+    threats.'
+
 CP-7 (2):
   family: CP
   name: Alternate Processing Site | Accessibility
+  description: |
+    'The organization identifies potential accessibility problems to the
+    alternate processing site in the event of an area-wide disruption or
+    disaster and outlines explicit mitigation actions.'
+
 CP-7 (3):
   family: CP
   name: Alternate Processing Site | Priority of Service
+  description: |
+    'The organization develops alternate processing site agreements that contain
+    priority-of-service provisions in accordance with organizational
+    availability requirements (including recovery time objectives).'
+
 CP-8:
   family: CP
   name: Telecommunications Services
+  description: |
+    'The organization establishes alternate telecommunications services
+    including necessary agreements to permit the resumption of [Assignment:
+    organization-defined information system operations] for essential missions
+    and business functions within [Assignment: organization-defined time period]
+    when the primary telecommunications capabilities are unavailable at either
+    the primary or alternate processing or storage sites.'
+
 CP-8 (1):
   family: CP
   name: Telecommunications Services | Priority of Service Provisions
+  description: |
+    'The organization:
+    CP-8 (1)(a)	Develops primary and alternate telecommunications service agreements that contain priority-of-service provisions in accordance with organizational availability requirements (including recovery time objectives); and
+    CP-8 (1)(b)	Requests Telecommunications Service Priority for all telecommunications services used for national security emergency preparedness in the event that the primary and/or alternate telecommunications services are provided by a common carrier.'
+
 CP-8 (2):
   family: CP
   name: Telecommunications Services | Single Points of Failure
+  description: |
+    'The organization obtains alternate telecommunications services to reduce
+    the likelihood of sharing a single point of failure with primary
+    telecommunications services.'
+
 CP-9:
   family: CP
   name: Information System Backup
+  description: |
+    'The organization:
+    a.	Conducts backups of user-level information contained in the information system [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives];
+    b.	Conducts backups of system-level information contained in the information system [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives];
+    c.	Conducts backups of information system documentation including security-related documentation [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives]; and
+    d.	Protects the confidentiality, integrity, and availability of backup information at storage locations.'
+
 CP-9 (1):
   family: CP
   name: Information System Backup | Testing For Reliability / Integrity
+  description: |
+    'The organization tests backup information [Assignment: organization-defined
+    frequency] to verify media reliability and information integrity.'
+
 CP-9 (3):
   family: CP
   name: Information System Backup | Separate Storage for Critical Information
+  description: |
+    'The organization stores backup copies of [Assignment: organization-defined
+    critical information system software and other security-related information]
+    in a separate facility or in a fire-rated container that is not collocated
+    with the operational system.'
+
+CP-10:
+  family: CP
+  name: Information System Recovery and Reconstitution
+  description: |
+    'The organization provides for the recovery and reconstitution of the
+    information system to a known state after a disruption, compromise, or
+    failure.'
+
+CP-10 (2):
+  family: CP
+  name: Information System Recovery and Reconstitution | Transaction Recovery
+  description: |
+    'The information system implements transaction recovery for systems that are
+    transaction-based.'
+
 IA-1:
   family: IA
   name: Identification and Authentication Policy and Procedures
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	An identification and authentication policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the identification and authentication policy and associated identification and authentication controls; and
+    b.	Reviews and updates the current:
+      1.	Identification and authentication policy [Assignment: organization-defined frequency]; and
+      2.	Identification and authentication procedures [Assignment: organization-defined frequency].'
+
 IA-2:
   family: IA
   name: Identification and Authentication (Organizational Users)
+  description: |
+    'The information system uniquely identifies and authenticates organizational
+    users (or processes acting on behalf of organizational users).'
+
 IA-2 (1):
   family: IA
   name: Identification and Authentication (Organizational Users) | Network Access
     to Privileged Accounts
-IA-2 (11):
-  family: IA
-  name: Identification and Authentication (Organizational Users) | Remote Access -
-    Separate Device
-IA-2 (12):
-  family: IA
-  name: Identification and Authentication (Organizational Users) | Acceptance of PIV
-    Credentials
+  description: |
+    'The information system implements multifactor authentication for network
+    access to privileged accounts.'
+
 IA-2 (2):
   family: IA
   name: Identification and Authentication (Organizational Users) | Network Access
     to Non-Privileged Accounts
+  description: |
+    'The information system implements multifactor authentication for network
+    access to non-privileged accounts.'
+
 IA-2 (3):
   family: IA
   name: Identification and Authentication (Organizational Users) | Local Access to
     Privileged Accounts
+  description: |
+    'The information system implements multifactor authentication for local
+    access to privileged accounts.'
+
 IA-2 (5):
   family: IA
   name: Identification and Authentication (Organizational Users) | Group Authentication
+  description: |
+    'The organization requires individuals to be authenticated with an
+    individual authenticator when a group authenticator is employed.'
+
 IA-2 (8):
   family: IA
   name: Identification and Authentication (Organizational Users) | Network Access
     to Privileged Accounts - Replay Resistant
+  description: |
+    'The information system implements replay-resistant authentication
+    mechanisms for network access to privileged accounts.'
+
+IA-2 (11):
+  family: IA
+  name: Identification and Authentication (Organizational Users) | Remote Access -
+    Separate Device
+  description: |
+    'The information system implements multifactor authentication for remote
+    access to privileged and non-privileged accounts such that one of the
+    factors is provided by a device separate from the system gaining access and
+    the device meets [Assignment: organization-defined strength of mechanism
+    requirements].'
+
+IA-2 (12):
+  family: IA
+  name: Identification and Authentication (Organizational Users) | Acceptance of PIV
+    Credentials
+  description: |
+    'The information system accepts and electronically verifies Personal
+    Identity Verification (PIV) credentials.'
+
 IA-3:
   family: IA
   name: Device Identification and Authentication
+  description: |
+    'The information system uniquely identifies and authenticates [Assignment:
+    organization-defined specific and/or types of devices] before establishing a
+    [Selection (one or more): local; remote; network] connection.'
+
 IA-4:
   family: IA
   name: Identifier Management
+  description: |
+    'The organization manages information system identifiers by:
+    a.	Receiving authorization from [Assignment: organization-defined personnel or roles] to assign an individual, group, role, or device identifier;
+    b.	Selecting an identifier that identifies an individual, group, role, or device;
+    c.	Assigning the identifier to the intended individual, group, role, or device;
+    d.	Preventing reuse of identifiers for [Assignment: organization-defined time period]; and
+    e.	Disabling the identifier after [Assignment: organization-defined time period of inactivity].'
+
 IA-4 (4):
   family: IA
   name: Identifier Management | Identify User Status
+  description: |
+    'The organization manages individual identifiers by uniquely identifying each individual as [Assignment: organization-defined characteristic identifying individual status].'
+
 IA-5:
   family: IA
   name: Authenticator Management
+  description: |
+    'The organization manages information system authenticators by:
+    a.	Verifying, as part of the initial authenticator distribution, the identity of the individual, group, role, or device receiving the authenticator;
+    b.	Establishing initial authenticator content for authenticators defined by the organization;
+    c.	Ensuring that authenticators have sufficient strength of mechanism for their intended use;
+    d.	Establishing and implementing administrative procedures for initial authenticator distribution, for lost/compromised or damaged authenticators, and for revoking authenticators;
+    e.	Changing default content of authenticators prior to information system installation;
+    f.	Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators;
+    g.	Changing/refreshing authenticators [Assignment: organization-defined time period by authenticator type];
+    h.	Protecting authenticator content from unauthorized disclosure and modification;
+    i.	Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators; and
+    j.	Changing authenticators for group/role accounts when membership to those accounts changes.'
+
 IA-5 (1):
   family: IA
   name: Authenticator Management | Password-Based Authentication
-IA-5 (11):
-  family: IA
-  name: Authenticator Management | Hardware Token-Based Authentication
+  description: |
+    'The information system, for password-based authentication:
+    IA-5 (1)(a)	Enforces minimum password complexity of [Assignment: organization-defined requirements for case sensitivity, number of characters, mix of upper-case letters, lower-case letters, numbers, and special characters, including minimum requirements for each type];
+    IA-5 (1)(b)	Enforces at least the following number of changed characters when new passwords are created: [Assignment: organization-defined number];
+    IA-5 (1)(c)	Stores and transmits only cryptographically-protected passwords;
+    IA-5 (1)(d)	Enforces password minimum and maximum lifetime restrictions of [Assignment: organization-defined numbers for lifetime minimum, lifetime maximum];
+    IA-5 (1)(e)	Prohibits password reuse for [Assignment: organization-defined number] generations; and
+    IA-5 (1)(f)	Allows the use of a temporary password for system logons with an immediate change to a permanent password.'
+
 IA-5 (2):
   family: IA
   name: Authenticator Management | PKI-Based Authentication
+  description: |
+    'The information system, for PKI-based authentication:
+    IA-5 (2)(a) Validates certifications by constructing and verifying a certification path to an accepted trust anchor including checking certificate status information;
+    IA-5 (2)(b)	Enforces authorized access to the corresponding private key;
+    IA-5 (2)(c)	Maps the authenticated identity to the account of the individual or group; and
+    IA-5 (2)(d)	Implements a local cache of revocation data to support path discovery and validation in case of inability to access revocation information via the network.'
+
 IA-5 (3):
   family: IA
   name: Authenticator Management | In-Person or Trusted Third-Party Registration
+  description: |
+    'The organization requires that the registration process to receive
+    [Assignment: organization-defined types of and/or specific authenticators]
+    be conducted [Selection: in person; by a trusted third party] before
+    [Assignment: organization-defined registration authority] with authorization
+    by [Assignment: organization-defined personnel or roles].'
+
 IA-5 (4):
   family: IA
   name: Authenticator Management | Automated Support for Password Strength Determination
+  description: |
+    'The organization employs automated tools to determine if password
+    authenticators are sufficiently strong to satisfy [Assignment:
+    organization-defined requirements].'
+
 IA-5 (6):
   family: IA
   name: Authenticator Management | Protection of Authenticators
+  description: |
+    'The organization protects authenticators commensurate with the security
+    category of the information to which use of the authenticator permits
+    access.'
+
 IA-5 (7):
   family: IA
   name: Authenticator Management | No Embedded Unencrypted Static Authenticators
+  description: |
+    'The organization ensures that unencrypted static authenticators are not
+    embedded in applications or access scripts or stored on function keys.'
+
+IA-5 (11):
+  family: IA
+  name: Authenticator Management | Hardware Token-Based Authentication
+  description: |
+    'The information system, for hardware token-based authentication, employs
+    mechanisms that satisfy [Assignment: organization-defined token quality
+    requirements].'
+
 IA-6:
   family: IA
   name: Authenticator Feedback
+  description: |
+    'The information system obscures feedback of authentication information
+    during the authentication process to protect the information from possible
+    exploitation/use by unauthorized individuals.'
+
 IA-7:
   family: IA
   name: Cryptographic Module Authentication
+  description: |
+    'The information system implements mechanisms for authentication to a
+    cryptographic module that meet the requirements of applicable federal laws,
+    Executive Orders, directives, policies, regulations, standards, and guidance
+    for such authentication.'
+
 IA-8:
   family: IA
   name: Identification and Authentication (Non-Organizational Users)
+  description: |
+    'The information system uniquely identifies and authenticates
+    non-organizational users (or processes acting on behalf of
+    non-organizational users).'
+
 IA-8 (1):
   family: IA
   name: Identification and Authentication (Non-Organizational Users) | Acceptance
     of PIV Credentials from Other Agencies
+  description: |
+    'The information system accepts and electronically verifies Personal
+    Identity Verification (PIV) credentials from other federal agencies.'
+
 IA-8 (2):
   family: IA
   name: Identification and Authentication (Non-Organizational Users) | Acceptance
     of Third-Party Credentials
+  description: |
+    'The information system accepts only FICAM-approved third-party
+    credentials.'
+
 IA-8 (3):
   family: IA
   name: Identification and Authentication (Non-Organizational Users) | Use of FICAM-Approved
     Products
+  description: |
+    'The organization employs only FICAM-approved information system components
+    in [Assignment: organization-defined information systems] to accept
+    third-party credentials.'
+
 IA-8 (4):
   family: IA
   name: Identification and Authentication (Non-Organizational Users) | Use of FICAM-Issued
     Profiles
+  description: |
+    'The information system conforms to FICAM-issued profiles.'
+
 IR-1:
   family: IR
   name: Incident Response Policy and Procedures
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	An incident response policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the incident response policy and associated incident response controls; and
+    b.	Reviews and updates the current:
+      1.	Incident response policy [Assignment: organization-defined frequency]; and
+      2.	Incident response procedures [Assignment: organization-defined frequency].'
+
 IR-2:
   family: IR
   name: Incident Response Training
+  description: |
+    'The organization provides incident response training to information system users consistent with assigned roles and responsibilities:
+    a.	Within [Assignment: organization-defined time period] of assuming an incident response role or responsibility;
+    b.	When required by information system changes; and
+    c.	[Assignment: organization-defined frequency] thereafter.'
+
 IR-3:
   family: IR
   name: Incident Response Testing
+  description: |
+    'The organization tests the incident response capability for the information
+    system [Assignment: organization-defined frequency] using [Assignment:
+    organization-defined tests] to determine the incident response effectiveness
+    and documents the results.'
+
 IR-3 (2):
   family: IR
   name: Incident Response Testing | Coordination With Related Plans
+  description: |
+    'The organization coordinates incident response testing with organizational
+    elements responsible for related plans.'
+
 IR-4:
   family: IR
   name: Incident Handling
+  description: |
+    'The organization:
+    a.	Implements an incident handling capability for security incidents that includes preparation, detection and analysis, containment, eradication, and recovery;
+    b.	Coordinates incident handling activities with contingency planning activities; and
+    c.	Incorporates lessons learned from ongoing incident handling activities into incident response procedures, training, and testing, and implements the resulting changes accordingly.'
+
 IR-4 (1):
   family: IR
   name: Incident Handling | Automated Incident Handling Processes
+  description: |
+    'The organization employs automated mechanisms to support the incident
+    handling process.'
+
 IR-5:
   family: IR
   name: Incident Monitoring
+  description: |
+    'The organization tracks and documents information system security
+    incidents.'
+
 IR-6:
   family: IR
   name: Incident Reporting
+  description: |
+    'The organization:
+    a.	Requires personnel to report suspected security incidents to the organizational incident response capability within [Assignment: organization-defined time period]; and
+    b.	Reports security incident information to [Assignment: organization-defined authorities].'
+
 IR-6 (1):
   family: IR
   name: Incident Reporting | Automated Reporting
+  description: |
+    'The organization employs automated mechanisms to assist in the reporting of
+    security incidents.'
+
 IR-7:
   family: IR
   name: Incident Response Assistance
+  description: |
+    'The organization provides an incident response support resource, integral
+    to the organizational incident response capability that offers advice and
+    assistance to users of the information system for the handling and reporting
+    of security incidents.'
+
 IR-7 (1):
   family: IR
   name: Incident Response Assistance | Automation Support For Availability of Information
     / Support
+  description: |
+    'The organization employs automated mechanisms to increase the availability
+    of incident response-related information and support.'
+
 IR-7 (2):
   family: IR
   name: Incident Response Assistance | Coordination With External Providers
+  description: |
+    'The organization:
+    IR-7 (2)(a)	Establishes a direct, cooperative relationship between its incident response capability and external providers of information system protection capability; and
+    IR-7 (2)(b)	Identifies organizational incident response team members to the external providers.'
+
 IR-8:
   family: IR
   name: Incident Response Plan
+  description: |
+    'The organization:
+    a.	Develops an incident response plan that:
+      1.	Provides the organization with a roadmap for implementing its incident response capability;
+      2.	Describes the structure and organization of the incident response capability;
+      3.	Provides a high-level approach for how the incident response capability fits into the overall organization;
+      4.	Meets the unique requirements of the organization, which relate to mission, size, structure, and functions;
+      5.	Defines reportable incidents;
+      6.	Provides metrics for measuring the incident response capability within the organization;
+      7.	Defines the resources and management support needed to effectively maintain and mature an incident response capability; and
+      8.	Is reviewed and approved by [Assignment: organization-defined personnel or roles];
+    b.	Distributes copies of the incident response plan to [Assignment: organization-defined incident response personnel (identified by name and/or by role) and organizational elements];
+    c.	Reviews the incident response plan [Assignment: organization-defined frequency];
+    d.	Updates the incident response plan to address system/organizational changes or problems encountered during plan implementation, execution, or testing;
+    e.	Communicates incident response plan changes to [Assignment: organization-defined incident response personnel (identified by name and/or by role) and organizational elements]; and
+    f.	Protects the incident response plan from unauthorized disclosure and modification.'
+
 IR-9:
   family: IR
   name: Information Spillage Response
+  description: |
+    'The organization responds to information spills by:
+    a.	Identifying the specific information involved in the information system contamination;
+    b.	Alerting [Assignment: organization-defined personnel or roles] of the information spill using a method of communication not associated with the spill;
+    c.	Isolating the contaminated information system or system component;
+    d.	Eradicating the information from the contaminated information system or component;
+    e.	Identifying other information systems or system components that may have been subsequently contaminated; and
+    f.	Performing other [Assignment: organization-defined actions].'
+
 IR-9 (1):
   family: IR
   name: Information Spillage Response | Responsible Personnel
+  description: |
+    'The organization assigns [Assignment: organization-defined personnel or
+    roles] with responsibility for responding to information spills.'
+
 IR-9 (2):
   family: IR
   name: Information Spillage Response | Training
+  description: |
+    'The organization provides information spillage response training
+    [Assignment: organization-defined frequency].'
+
 IR-9 (3):
   family: IR
   name: Information Spillage Response | Post-Spill Operations
+  description: |
+    'The organization implements [Assignment: organization-defined procedures]
+    to ensure that organizational personnel impacted by information spills can
+    continue to carry out assigned tasks while contaminated systems are
+    undergoing corrective actions.'
+
 IR-9 (4):
   family: IR
   name: Information Spillage Response | Exposure to Unauthorized Personnel
+  description: |
+    'The organization employs [Assignment: organization-defined security
+    safeguards] for personnel exposed to information not within assigned access
+    authorizations.'
+
 MA-1:
   family: MA
   name: System Maintenance Policy and Procedures
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	A system maintenance policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the system maintenance policy and associated system maintenance controls; and
+    b.	Reviews and updates the current:
+      1.	System maintenance policy [Assignment: organization-defined frequency]; and
+      2.	System maintenance procedures [Assignment: organization-defined frequency].'
+
 MA-2:
   family: MA
   name: Controlled Maintenance
+  description: |
+    'The organization:
+    a.	Schedules, performs, documents, and reviews records of maintenance and repairs on information system components in accordance with manufacturer or vendor specifications and/or organizational requirements;
+    b.	Approves and monitors all maintenance activities, whether performed on site or remotely and whether the equipment is serviced on site or removed to another location;
+    c.	Requires that [Assignment: organization-defined personnel or roles] explicitly approve the removal of the information system or system components from organizational facilities for off-site maintenance or repairs;
+    d.	Sanitizes equipment to remove all information from associated media prior to removal from organizational facilities for off-site maintenance or repairs;
+    e.	Checks all potentially impacted security controls to verify that the controls are still functioning properly following maintenance or repair actions; and
+    f.	Includes [Assignment: organization-defined maintenance-related information] in organizational maintenance records.'
+
 MA-3:
   family: MA
   name: Maintenance Tools
+  description: |
+    'The organization approves, controls, and monitors information system
+    maintenance tools.'
+
 MA-3 (1):
   family: MA
   name: Maintenance Tools | Inspect Tools
+  description: |
+    'The organization inspects the maintenance tools carried into a facility by
+    maintenance personnel for improper or unauthorized modifications.'
+
 MA-3 (2):
   family: MA
   name: Maintenance Tools | Inspect Media
+  description: |
+    'The organization checks media containing diagnostic and test programs for
+    malicious code before the media are used in the information system.'
+
 MA-3 (3):
   family: MA
   name: Maintenance Tools | Prevent Unauthorized Removal
+  description: |
+    'The organization prevents the unauthorized removal of maintenance equipment containing organizational information by:
+    MA-3 (3)(a)	Verifying that there is no organizational information contained on the equipment;
+    MA-3 (3)(b)	Sanitizing or destroying the equipment;
+    MA-3 (3)(c)	Retaining the equipment within the facility; or
+    MA-3 (3)(d)	Obtaining an exemption from [Assignment: organization-defined personnel or roles] explicitly authorizing removal of the equipment from the facility.'
+
 MA-4:
   family: MA
   name: Nonlocal Maintenance
+  description: |
+    'The organization:
+    a.	Approves and monitors nonlocal maintenance and diagnostic activities;
+    b.	Allows the use of nonlocal maintenance and diagnostic tools only as consistent with organizational policy and documented in the security plan for the information system;
+    c.	Employs strong authenticators in the establishment of nonlocal maintenance and diagnostic sessions;
+    d.	Maintains records for nonlocal maintenance and diagnostic activities; and
+    e.	Terminates session and network connections when nonlocal maintenance is completed.'
+
 MA-4 (2):
   family: MA
   name: Nonlocal Maintenance | Document Nonlocal Maintenance
+  description: |
+    'The organization documents in the security plan for the information system,
+    the policies and procedures for the establishment and use of nonlocal
+    maintenance and diagnostic connections.'
+
 MA-5:
   family: MA
   name: Maintenance Personnel
+  description: |
+    'The organization:
+    a.	Establishes a process for maintenance personnel authorization and maintains a list of authorized maintenance organizations or personnel;
+    b.	Ensures that non-escorted personnel performing maintenance on the information system have required access authorizations; and
+    c.	Designates organizational personnel with required access authorizations and technical competence to supervise the maintenance activities of personnel who do not possess the required access authorizations.'
+
 MA-5 (1):
   family: MA
   name: Maintenance Personnel | Individuals Without Appropriate Access
+  description: |
+    'The organization:
+    MA-5 (1)(a) Implements procedures for the use of maintenance personnel that lack appropriate security clearances or are not U.S. citizens, that include the following requirements:
+    MA-5 (1)(b) Develops and implements alternate security safeguards in the event an information system component cannot be sanitized, removed, or disconnected from the system.'
+
 MA-6:
   family: MA
   name: Timely Maintenance
+  description: |
+    'The organization obtains maintenance support and/or spare parts for
+    [Assignment: organization-defined information system components] within
+    [Assignment: organization-defined time period] of failure.'
+
 MP-1:
   family: MP
   name: Media Protection Policy and Procedures
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	A media protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the media protection policy and associated media protection controls; and
+    b.	Reviews and updates the current:
+      1.	Media protection policy [Assignment: organization-defined frequency]; and
+      2.	Media protection procedures [Assignment: organization-defined frequency].'
+
 MP-2:
   family: MP
   name: Media Access
+  description: |
+    'The organization restricts access to [Assignment: organization-defined
+    types of digital and/or non-digital media] to [Assignment:
+    organization-defined personnel or roles].'
+
 MP-3:
   family: MP
   name: Media Marking
+  description: |
+    'The organization:
+    a.	Marks information system media indicating the distribution limitations, handling caveats, and applicable security markings (if any) of the information; and
+    b.	Exempts [Assignment: organization-defined types of information system media] from marking as long as the media remain within [Assignment: organization-defined controlled areas].'
+
 MP-4:
   family: MP
   name: Media Storage
+  description: |
+    'The organization:
+    a.	Physically controls and securely stores [Assignment: organization-defined types of digital and/or non-digital media] within [Assignment: organization-defined controlled areas]; and
+    b.	Protects information system media until the media are destroyed or sanitized using approved equipment, techniques, and procedures.'
+
 MP-5:
   family: MP
   name: Media Transport
+  description: |
+    'The organization:
+    a.	Protects and controls [Assignment: organization-defined types of information system media] during transport outside of controlled areas using [Assignment: organization-defined security safeguards];
+    b.	Maintains accountability for information system media during transport outside of controlled areas;
+    c.	Documents activities associated with the transport of information system media; and
+    d.	Restricts the activities associated with the transport of information system media to authorized personnel.'
+
 MP-5 (4):
   family: MP
   name: Media Transport | Cryptographic Protection
+  description: |
+    'The information system implements cryptographic mechanisms to protect the
+    confidentiality and integrity of information stored on digital media during
+    transport outside of controlled areas.'
+
 MP-6:
   family: MP
   name: Media Sanitization
+  description: |
+    'The organization:
+    a.	Sanitizes [Assignment: organization-defined information system media] prior to disposal, release out of organizational control, or release for reuse using [Assignment: organization-defined sanitization techniques and procedures] in accordance with applicable federal and organizational standards and policies; and
+    b.	Employs sanitization mechanisms with the strength and integrity commensurate with the security category or classification of the information.'
+
 MP-6 (2):
   family: MP
   name: Media Sanitization | Equipment Testing
+  description: |
+    'The organization tests sanitization equipment and procedures [Assignment:
+    organization-defined frequency] to verify that the intended sanitization is
+    being achieved.'
+
 MP-7:
   family: MP
   name: Media Use
+  description: |
+    'The organization [Selection: restricts; prohibits] the use of [Assignment:
+    organization-defined types of information system media] on [Assignment:
+    organization-defined information systems or system components] using
+    [Assignment: organization-defined security safeguards].'
+
 MP-7 (1):
   family: MP
   name: Media Use | Prohibit Use without Owner
+  description: |
+    'The organization prohibits the use of portable storage devices in
+    organizational information systems when such devices have no identifiable
+    owner.'
+
 PE-1:
   family: PE
   name: Physical and Environmental Protection Policy and Procedures
-PE-10:
-  family: PE
-  name: Emergency Shutoff
-PE-11:
-  family: PE
-  name: Emergency Power
-PE-12:
-  family: PE
-  name: Emergency Lighting
-PE-13:
-  family: PE
-  name: Fire Protection
-PE-13 (2):
-  family: PE
-  name: Fire Protection | Suppression Devices / Systems
-PE-13 (3):
-  family: PE
-  name: Fire Protection | Automatic Fire Suppression
-PE-14:
-  family: PE
-  name: Temperature and Humidity Controls
-PE-14 (2):
-  family: PE
-  name: Temperature and Humidity Controls | Monitoring With Alarms / Notifications
-PE-15:
-  family: PE
-  name: Water Damage Protection
-PE-16:
-  family: PE
-  name: Delivery and Removal
-PE-17:
-  family: PE
-  name: Alternate Work Site
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	A physical and environmental protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the physical and environmental protection policy and associated physical and environmental protection controls; and
+    b.	Reviews and updates the current:
+      1.	Physical and environmental protection policy [Assignment: organization-defined frequency]; and
+      2.	Physical and environmental protection procedures [Assignment: organization-defined frequency].'
+
 PE-2:
   family: PE
   name: Physical Access Authorizations
+  description: |
+    'The organization:
+    a.	Develops, approves, and maintains a list of individuals with authorized access to the facility where the information system resides;
+    b.	Issues authorization credentials for facility access;
+    c.	Reviews the access list detailing authorized facility access by individuals [Assignment: organization-defined frequency]; and
+    d.	Removes individuals from the facility access list when access is no longer required.'
+
 PE-3:
   family: PE
   name: Physical Access Control
+  description: |
+    'The organization:
+    a.	Enforces physical access authorizations at [Assignment: organization-defined entry/exit points to the facility where the information system resides] by;
+      1.	Verifying individual access authorizations before granting access to the facility; and
+      2.	Controlling ingress/egress to the facility using [Selection (one or more): [Assignment: organization-defined physical access control systems/devices]; guards];
+    b.	Maintains physical access audit logs for [Assignment: organization-defined entry/exit points];
+    c.	Provides [Assignment: organization-defined security safeguards] to control access to areas within the facility officially designated as publicly accessible;
+    d.	Escorts visitors and monitors visitor activity [Assignment: organization-defined circumstances requiring visitor escorts and monitoring];
+    e.	Secures keys, combinations, and other physical access devices;
+    f.	Inventories [Assignment: organization-defined physical access devices] every [Assignment: organization-defined frequency]; and
+    g.	Changes combinations and keys [Assignment: organization-defined frequency] and/or when keys are lost, combinations are compromised, or individuals are transferred or terminated.'
+
 PE-4:
   family: PE
   name: Access Control For Transmission Medium
+  description: |
+    'The organization controls physical access to [Assignment:
+    organization-defined information system distribution and transmission lines]
+    within organizational facilities using [Assignment: organization-defined
+    security safeguards].'
+
 PE-5:
   family: PE
   name: Access Control For Output Devices
+  description: |
+    'The organization controls physical access to information system output
+    devices to prevent unauthorized individuals from obtaining the output.'
+
 PE-6:
   family: PE
   name: Monitoring Physical Access
+  description: |
+    'The organization:
+    a.	Monitors physical access to the facility where the information system resides to detect and respond to physical security incidents;
+    b.	Reviews physical access logs [Assignment: organization-defined frequency] and upon occurrence of [Assignment: organization-defined events or potential indications of events]; and
+    c.	Coordinates results of reviews and investigations with the organizational incident response capability.'
+
 PE-6 (1):
   family: PE
   name: Monitoring Physical Access | Intrusion Alarms / Surveillance Equipment
+  description: |
+    'The organization monitors physical intrusion alarms and surveillance
+    equipment.'
+
 PE-8:
   family: PE
   name: Visitor Access Records
+  description: |
+    'The organization:
+    a.	Maintains visitor access records to the facility where the information
+    system resides for [Assignment: organization-defined time period]; and
+    b.	Reviews visitor access records [Assignment: organization-defined
+    frequency].'
+
 PE-9:
   family: PE
   name: Power Equipment and Cabling
+  description: |
+    'The organization protects power equipment and power cabling for the
+    information system from damage and destruction.'
+
+PE-10:
+  family: PE
+  name: Emergency Shutoff
+  description: |
+    'The organization:
+    a.	Provides the capability of shutting off power to the information system or individual system components in emergency situations;
+    b.	Places emergency shutoff switches or devices in [Assignment: organization-defined location by information system or system component] to facilitate safe and easy access for personnel; and
+    c.	Protects emergency power shutoff capability from unauthorized activation.'
+
+PE-11:
+  family: PE
+  name: Emergency Power
+  description: |
+    'The organization provides a short-term uninterruptible power supply to
+    facilitate [Selection (one or more): an orderly shutdown of the information
+    system; transition of the information system to long-term alternate power]
+    in the event of a primary power source loss.'
+
+PE-12:
+  family: PE
+  name: Emergency Lighting
+  description: |
+    'The organization employs and maintains automatic emergency lighting for the
+    information system that activates in the event of a power outage or
+    disruption and that covers emergency exits and evacuation routes within the
+    facility.'
+
+PE-13:
+  family: PE
+  name: Fire Protection
+  description: |
+    'The organization employs and maintains fire suppression and detection devices/systems for the information system that are supported by an independent energy source.'
+
+PE-13 (2):
+  family: PE
+  name: Fire Protection | Suppression Devices / Systems
+  description: |
+    'The organization employs fire suppression devices/systems for the
+    information system that provide automatic notification of any activation to
+    Assignment: organization-defined personnel or roles] and [Assignment:
+    organization-defined emergency responders].'
+
+PE-13 (3):
+  family: PE
+  name: Fire Protection | Automatic Fire Suppression
+  description: |
+    'The organization employs an automatic fire suppression capability for the information system when the facility is not staffed on a continuous basis.'
+
+PE-14:
+  family: PE
+  name: Temperature and Humidity Controls
+  description: |
+    'The organization:
+    a.	Maintains temperature and humidity levels within the facility where the information system resides at [Assignment: organization-defined acceptable levels]; and
+    b.	Monitors temperature and humidity levels [Assignment: organization-defined frequency].'
+
+PE-14 (2):
+  family: PE
+  name: Temperature and Humidity Controls | Monitoring With Alarms / Notifications
+  description: |
+    'The organization employs temperature and humidity monitoring that provides
+    an alarm or notification of changes potentially harmful to personnel or
+    equipment.'
+
+PE-15:
+  family: PE
+  name: Water Damage Protection
+  description: |
+    'The organization protects the information system from damage resulting from
+    water leakage by providing master shutoff or isolation valves that are
+    accessible, working properly, and known to key personnel.'
+
+PE-16:
+  family: PE
+  name: Delivery and Removal
+  description: |
+    'The organization authorizes, monitors, and controls [Assignment:
+    organization-defined types of information system components] entering and
+    exiting the facility and maintains records of those items.'
+
+PE-17:
+  family: PE
+  name: Alternate Work Site
+  description: |
+    'The organization:
+    a.	Employs [Assignment: organization-defined security controls] at alternate work sites;
+    b.	Assesses as feasible, the effectiveness of security controls at alternate work sites; and
+    c.	Provides a means for employees to communicate with information security personnel in case of security incidents or problems.'
+
 PL-1:
   family: PL
   name: Security Planning Policy and Procedures
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	A security planning policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the security planning policy and associated security planning controls; and
+    b.	Reviews and updates the current:
+      1.	Security planning policy [Assignment: organization-defined frequency]; and
+      2.	Security planning procedures [Assignment: organization-defined frequency].'
+
 PL-2:
   family: PL
   name: System Security Plan
+  description: |
+    'The organization:
+    a.	Develops a security plan for the information system that:
+      1.	Is consistent with the organization''s enterprise architecture;
+      2.	Explicitly defines the authorization boundary for the system;
+      3.	Describes the operational context of the information system in terms of missions and business processes;
+      4.	Provides the security categorization of the information system including supporting rationale;
+      5.	Describes the operational environment for the information system and relationships with or connections to other information systems;
+      6.	Provides an overview of the security requirements for the system;
+      7.	Identifies any relevant overlays, if applicable;
+      8.	Describes the security controls in place or planned for meeting those requirements including a rationale for the tailoring decisions; and
+      9.	Is reviewed and approved by the authorizing official or designated representative prior to plan implementation;
+    b.	Distributes copies of the security plan and communicates subsequent changes to the plan to [Assignment: organization-defined personnel or roles];
+    c.	Reviews the security plan for the information system [Assignment: organization-defined frequency];
+    d.	Updates the plan to address changes to the information system/environment of operation or problems identified during plan implementation or security control assessments; and
+    e.	Protects the security plan from unauthorized disclosure and modification.'
+
 PL-2 (3):
   family: PL
   name: System Security Plan | Plan / Coordinate With Other Organizational Entities
+  description: |
+    'The organization plans and coordinates security-related activities
+    affecting the information system with [Assignment: organization-defined
+    individuals or groups] before conducting such activities in order to reduce
+    the impact on other organizational entities.'
+
 PL-4:
   family: PL
   name: Rules of Behavior
+  description: |
+    'The organization:
+    a.	Establishes and makes readily available to individuals requiring access to the information system, the rules that describe their responsibilities and expected behavior with regard to information and information system usage;
+    b.	Receives a signed acknowledgment from such individuals, indicating that they have read, understand, and agree to abide by the rules of behavior, before authorizing access to information and the information system;
+    c.	Reviews and updates the rules of behavior [Assignment: organization-defined frequency]; and
+    d.	Requires individuals who have signed a previous version of the rules of behavior to read and re-sign when the rules of behavior are revised/updated.'
+
 PL-4 (1):
   family: PL
   name: Rules of Behavior | Social Media and Networking Restrictions
+  description: |
+    'The organization includes in the rules of behavior, explicit restrictions
+    on the use of social media/networking sites and posting organizational
+    information on public websites.'
+
 PL-8:
   family: PL
   name: Information Security Architecture
+  description: |
+    'The organization:
+    a.	Develops an information security architecture for the information system that:
+      1.	Describes the overall philosophy, requirements, and approach to be taken with regard to protecting the confidentiality, integrity, and availability of organizational information;
+      2.	Describes how the information security architecture is integrated into and supports the enterprise architecture; and
+      3.	Describes any information security assumptions about, and dependencies on, external services;
+    b.	Reviews and updates the information security architecture [Assignment: organization-defined frequency] to reflect updates in the enterprise architecture; and
+    c.	Ensures that planned information security architecture changes are reflected in the security plan, the security Concept of Operations (CONOPS), and organizational procurements/acquisitions.'
+
 PS-1:
   family: PS
   name: Personnel Security Policy and Procedures
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	A personnel security policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the personnel security policy and associated personnel security controls; and
+    b.	Reviews and updates the current:
+      1.	Personnel security policy [Assignment: organization-defined frequency]; and
+      2.	Personnel security procedures [Assignment: organization-defined frequency].'
+
 PS-2:
   family: PS
   name: Position Risk Designation
+  description: |
+    'The organization:
+    a.	Assigns a risk designation to all organizational positions;
+    b.	Establishes screening criteria for individuals filling those positions; and
+    c.	Reviews and updates position risk designations [Assignment: organization-defined frequency].'
+
 PS-3:
   family: PS
   name: Personnel Screening
+  description: |
+    'The organization:
+    a.	Screens individuals prior to authorizing access to the information
+    system; and
+    b.	Rescreens individuals according to [Assignment: organization-defined
+    conditions requiring rescreening and, where rescreening is so indicated, the
+    frequency of such rescreening].'
+
 PS-3 (3):
   family: PS
   name: Personnel Screening | Information With Special Protection Measures
+  description: |
+    'The organization ensures that individuals accessing an information system processing, storing, or transmitting information requiring special protection:
+    PS-3 (3)(a)	Have valid access authorizations that are demonstrated by assigned official government duties; and
+    PS-3 (3)(b) Satisfy [Assignment: organization-defined additional personnel screening criteria].'
+
 PS-4:
   family: PS
   name: Personnel Termination
+  description: |
+    'The organization, upon termination of individual employment:
+    a.	Disables information system access within [Assignment: organization-defined time period];
+    b.	Terminates/revokes any authenticators/credentials associated with the individual;
+    c.	Conducts exit interviews that include a discussion of [Assignment: organization-defined information security topics];
+    d.	Retrieves all security-related organizational information system-related property;
+    e.	Retains access to organizational information and information systems formerly controlled by terminated individual; and
+    f.	Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period].'
+
 PS-5:
   family: PS
   name: Personnel Transfer
+  description: |
+    'The organization:
+    a.	Reviews and confirms ongoing operational need for current logical and physical access authorizations to information systems/facilities when individuals are reassigned or transferred to other positions within the organization;
+    b.	Initiates [Assignment: organization-defined transfer or reassignment actions] within [Assignment: organization-defined time period following the formal transfer action];
+    c.	Modifies access authorization as needed to correspond with any changes in operational need due to reassignment or transfer; and
+    d.	Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period].'
+
 PS-6:
   family: PS
   name: Access Agreements
+  description: |
+    'The organization:
+    a.	Develops and documents access agreements for organizational information systems;
+    b.	Reviews and updates the access agreements [Assignment: organization-defined frequency]; and
+    c.	Ensures that individuals requiring access to organizational information and information systems:
+      1.	Sign appropriate access agreements prior to being granted access; and
+      2.	Re-sign access agreements to maintain access to organizational information systems when access agreements have been updated or [Assignment: organization-defined frequency].'
+
 PS-7:
   family: PS
   name: Third-Party Personnel Security
+  description: |
+    'The organization:
+    a.	Establishes personnel security requirements including security roles and responsibilities for third-party providers;
+    b.	Requires third-party providers to comply with personnel security policies and procedures established by the organization;
+    c.	Documents personnel security requirements;
+    d.	Requires third-party providers to notify [Assignment: organization-defined personnel or roles] of any personnel transfers or terminations of third-party personnel who possess organizational credentials and/or badges, or who have information system privileges within [Assignment: organization-defined time period]; and
+    e.	Monitors provider compliance.'
+
 PS-8:
   family: PS
   name: Personnel Sanctions
+  description: |
+    'The organization:
+    a.	Employs a formal sanctions process for individuals failing to comply with established information security policies and procedures; and
+    b.	Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period] when a formal employee sanctions process is initiated, identifying the individual sanctioned and the reason for the sanction.'
+
 RA-1:
   family: RA
   name: Risk Assessment Policy and Procedures
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	A risk assessment policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the risk assessment policy and associated risk assessment controls; and
+    b.	Reviews and updates the current:
+      1.	Risk assessment policy [Assignment: organization-defined frequency]; and
+      2.	Risk assessment procedures [Assignment: organization-defined frequency].'
+
 RA-2:
   family: RA
   name: Security Categorization
+  description: |
+    'The organization:
+    a.	Categorizes information and the information system in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
+    b.	Documents the security categorization results (including supporting rationale) in the security plan for the information system; and
+    c.	Ensures that the authorizing official or authorizing official designated representative reviews and approves the security categorization decision.'
+
 RA-3:
   family: RA
   name: Risk Assessment
+  description: |
+    'The organization:
+    a.	Conducts an assessment of risk, including the likelihood and magnitude of harm, from the unauthorized access, use, disclosure, disruption, modification, or destruction of the information system and the information it processes, stores, or transmits;
+    b.	Documents risk assessment results in [Selection: security plan; risk assessment report; [Assignment: organization-defined document]];
+    c.	Reviews risk assessment results [Assignment: organization-defined frequency];
+    d.	Disseminates risk assessment results to [Assignment: organization-defined personnel or roles]; and
+    e.	Updates the risk assessment [Assignment: organization-defined frequency] or whenever there are significant changes to the information system or environment of operation (including the identification of new threats and vulnerabilities), or other conditions that may impact the security state of the system.'
+
 RA-5:
   family: RA
   name: Vulnerability Scanning
+  description: |
+    'The organization:
+    a.	Scans for vulnerabilities in the information system and hosted applications [Assignment: organization-defined frequency and/or randomly in accordance with organization-defined process] and when new vulnerabilities potentially affecting the system/applications are identified and reported;
+    b.	Employs vulnerability scanning tools and techniques that facilitate interoperability among tools and automate parts of the vulnerability management process by using standards for:
+      1.	Enumerating platforms, software flaws, and improper configurations;
+      2.	Formatting checklists and test procedures; and
+      3.	Measuring vulnerability impact;
+    c.	Analyzes vulnerability scan reports and results from security control assessments;
+    d.	Remediates legitimate vulnerabilities [Assignment: organization-defined response times] in accordance with an organizational assessment of risk; and
+    e.	Shares information obtained from the vulnerability scanning process and security control assessments with [Assignment: organization-defined personnel or roles] to help eliminate similar vulnerabilities in other information systems (i.e., systemic weaknesses or deficiencies).'
+
 RA-5 (1):
   family: RA
   name: Vulnerability Scanning | Update Tool Capability
+  description: |
+    'The organization employs vulnerability scanning tools that include the
+    capability to readily update the information system vulnerabilities to be
+    scanned.'
+
 RA-5 (2):
   family: RA
   name: Vulnerability Scanning | Update by Frequency / Prior to New Scan / When Identified
+  description: |
+    'The organization updates the information system vulnerabilities scanned
+    [Selection (one or more): [Assignment: organization-defined frequency];
+    prior to a new scan; when new vulnerabilities are identified and reported].'
+
 RA-5 (3):
   family: RA
   name: Vulnerability Scanning | Breadth / Depth of Coverage
+  description: |
+    'The organization employs vulnerability scanning procedures that can
+    identify the breadth and depth of coverage (i.e., information system
+    components scanned and vulnerabilities checked).'
+
 RA-5 (5):
   family: RA
   name: Vulnerability Scanning | Privileged Access
+  description: |
+    'The information system implements privileged access authorization to
+    [Assignment: organization-identified information system components] for
+    selected [Assignment: organization-defined vulnerability scanning
+    activities].'
+
 RA-5 (6):
   family: RA
   name: Vulnerability Scanning | Automated Trend Analyses
+  description: |
+    'The organization employs automated mechanisms to compare the results of
+    vulnerability scans over time to determine trends in information system
+    vulnerabilities.'
+
 RA-5 (8):
   family: RA
   name: Vulnerability Scanning | Review Historic Audit Logs
+  description: |
+    'The organization reviews historic audit logs to determine if a
+    vulnerability identified in the information system has been previously
+    exploited.'
+
 SA-1:
   family: SA
   name: System and Services Acquisition Policy and Procedures
-SA-10:
-  family: SA
-  name: Developer Configuration Management
-SA-10 (1):
-  family: SA
-  name: Developer Configuration Management | Software / Firmware Integrity Verification
-SA-11:
-  family: SA
-  name: Developer Security Testing and Evaluation
-SA-11 (1):
-  family: SA
-  name: Developer Security Testing and Evaluation | Static Code Analysis
-SA-11 (2):
-  family: SA
-  name: Developer Security Testing and Evaluation | Threat and Vulnerability Analyses
-SA-11 (8):
-  family: SA
-  name: Developer Security Testing and Evaluation | Dynamic Code Analysis
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	A system and services acquisition policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the system and services acquisition policy and associated system and services acquisition controls; and
+    b.	Reviews and updates the current:
+      1.	System and services acquisition policy [Assignment: organization-defined frequency]; and
+      2.	System and services acquisition procedures [Assignment: organization-defined frequency].'
+
 SA-2:
   family: SA
   name: Allocation of Resources
-SA-22:
-  family: SA
-  name: UNSUPPORTED SYSTEM COMPONENTS
+  description: |
+    'The organization:
+    a.	Determines information security requirements for the information system or information system service in mission/business process planning;
+    b.	Determines, documents, and allocates the resources required to protect the information system or information system service as part of its capital planning and investment control process; and
+    c.	Establishes a discrete line item for information security in organizational programming and budgeting documentation.'
+
 SA-3:
   family: SA
   name: System Development Life Cycle
+  description: |
+    'The organization:
+    a.	Manages the information system using [Assignment: organization-defined system development life cycle] that incorporates information security considerations;
+    b.	Defines and documents information security roles and responsibilities throughout the system development life cycle;
+    c.	Identifies individuals having information security roles and responsibilities; and
+    d.	Integrates the organizational information security risk management process into system development life cycle activities.'
+
 SA-4:
   family: SA
   name: Acquisition Process
+  description: |
+    'The organization includes the following requirements, descriptions, and
+    criteria, explicitly or by reference, in the acquisition contract for the
+    information system, system component, or information system service in
+    accordance with applicable federal laws, Executive Orders, directives,
+    policies, regulations, standards, guidelines, and organizational
+    mission/business needs:
+    a.	Security functional requirements;
+    b.	Security strength requirements;
+    c.	Security assurance requirements;
+    d.	Security-related documentation requirements;
+    e.	Requirements for protecting security-related documentation;
+    f.	Description of the information system development environment and
+    environment in which the system is intended to operate; and
+    g.	Acceptance criteria.'
+
 SA-4 (1):
   family: SA
   name: Acquisition Process | Functional Properties of Security Controls
-SA-4 (10):
-  family: SA
-  name: Acquisition Process | Use of Approved PIV Products
+  description: |
+    'The organization requires the developer of the information system, system
+    component, or information system service to provide a description of the
+    functional properties of the security controls to be employed.'
+
 SA-4 (2):
   family: SA
   name: Acquisition Process | Design / Implementation Information for Security Controls
+  description: |
+    'The organization requires the developer of the information system, system
+    component, or information system service to provide design and
+    implementation information for the security controls to be employed that
+    includes: [Selection (one or more): security-relevant external system
+    interfaces; high-level design; low-level design; source code or hardware
+    schematics; [Assignment: organization-defined design/implementation
+    information]] at [Assignment: organization-defined level of detail].'
+
 SA-4 (8):
   family: SA
   name: Acquisition Process | Continuous Monitoring Plan
+  description: |
+    'The organization requires the developer of the information system, system
+    component, or information system service to produce a plan for the
+    continuous monitoring of security control effectiveness that contains
+    [Assignment: organization-defined level of detail].'
+
 SA-4 (9):
   family: SA
   name: Acquisition Process | Functions / Ports / Protocols / Services in Use
+  description: |
+    'The organization requires the developer of the information system, system
+    component, or information system service to identify early in the system
+    development life cycle, the functions, ports, protocols, and services
+    intended for organizational use.'
+
+SA-4 (10):
+  family: SA
+  name: Acquisition Process | Use of Approved PIV Products
+  description: |
+    'The organization employs only information technology products on the FIPS
+    201-approved products list for Personal Identity Verification (PIV)
+    capability implemented within organizational information systems.'
+
 SA-5:
   family: SA
   name: Information System Documentation
+  description: |
+    'The organization:
+    a.	Obtains administrator documentation for the information system, system component, or information system service that describes:
+      1.	Secure configuration, installation, and operation of the system, component, or service;
+      2.	Effective use and maintenance of security functions/mechanisms; and
+      3.	Known vulnerabilities regarding configuration and use of administrative (i.e., privileged) functions;
+    b.	Obtains user documentation for the information system, system component, or information system service that describes:
+      1.	User-accessible security functions/mechanisms and how to effectively use those security functions/mechanisms;
+      2.	Methods for user interaction, which enables individuals to use the system, component, or service in a more secure manner; and
+      3.	User responsibilities in maintaining the security of the system, component, or service;
+    c.	Documents attempts to obtain information system, system component, or information system service documentation when such documentation is either unavailable or nonexistent and takes [Assignment: organization-defined actions] in response;
+    d.	Protects documentation as required, in accordance with the risk management strategy; and
+    e.	Distributes documentation to [Assignment: organization-defined personnel or roles].'
+
 SA-8:
   family: SA
   name: Security Engineering Principles
+  description: |
+    'The organization applies information system security engineering principles
+    in the specification, design, development, implementation, and modification
+    of the information system.'
+
 SA-9:
   family: SA
   name: External Information System Services
+  description: |
+    'The organization:
+    a.	Requires that providers of external information system services comply with organizational information security requirements and employ [Assignment: organization-defined security controls] in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
+    b.	Defines and documents government oversight and user roles and responsibilities with regard to external information system services; and
+    c.	Employs [Assignment: organization-defined processes, methods, and techniques] to monitor security control compliance by external service providers on an ongoing basis.'
+
 SA-9 (1):
   family: SA
   name: External Information Systems | Risk Assessments / Organizational Approvals
+  description: |
+    'The organization:
+    SA-9 (1)(a)	Conducts an organizational assessment of risk prior to the acquisition or outsourcing of dedicated information security services; and
+    SA-9 (1)(b)	Ensures that the acquisition or outsourcing of dedicated information security services is approved by [Assignment: organization-defined personnel or roles].'
+
 SA-9 (2):
   family: SA
   name: External Information Systems | Identification of Functions / Ports / Protocols
     / Services
+  description: |
+    'The organization requires providers of [Assignment: organization-defined
+    external information system services] to identify the functions, ports,
+    protocols, and other services required for the use of such services.'
+
 SA-9 (4):
   family: SA
   name: External Information Systems | Consistent Interests of Consumers and Providers
+  description: |
+    'The organization employs [Assignment: organization-defined security
+    safeguards] to ensure that the interests of [Assignment:
+    organization-defined external service providers] are consistent with and
+    reflect organizational interests.'
+
 SA-9 (5):
   family: SA
   name: External Information Systems | Processing, Storage, and Service Location
+  description: |
+    'The organization restricts the location of [Selection (one or more):
+    information processing; information/data; information system services] to
+    [Assignment: organization-defined locations] based on [Assignment:
+    organization-defined requirements or conditions].'
+
+SA-10:
+  family: SA
+  name: Developer Configuration Management
+  description: |
+    'The organization requires the developer of the information system, system component, or information system service to:
+    a.	Perform configuration management during system, component, or service [Selection (one or more): design; development; implementation; operation];
+    b.	Document, manage, and control the integrity of changes to [Assignment: organization-defined configuration items under configuration management];
+    c.	Implement only organization-approved changes to the system, component, or service;
+    d.	Document approved changes to the system, component, or service and the potential security impacts of such changes; and
+    e.	Track security flaws and flaw resolution within the system, component, or service and report findings to [Assignment: organization-defined personnel].'
+
+SA-10 (1):
+  family: SA
+  name: Developer Configuration Management | Software / Firmware Integrity Verification
+  description: |
+    'The organization requires the developer of the information system, system
+    component, or information system service to enable integrity verification of
+    software and firmware components.'
+
+SA-11:
+  family: SA
+  name: Developer Security Testing and Evaluation
+  description: |
+    'The organization requires the developer of the information system, system component, or information system service to:
+    a.	Create and implement a security assessment plan;
+    b.	Perform [Selection (one or more): unit; integration; system; regression] testing/evaluation at [Assignment: organization-defined depth and coverage];
+    c.	Produce evidence of the execution of the security assessment plan and the results of the security testing/evaluation;
+    d.	Implement a verifiable flaw remediation process; and
+    e.	Correct flaws identified during security testing/evaluation.'
+
+SA-11 (1):
+  family: SA
+  name: Developer Security Testing and Evaluation | Static Code Analysis
+  description: |
+    'The organization requires the developer of the information system, system
+    component, or information system service to employ static code analysis
+    tools to identify common flaws and document the results of the analysis.'
+
+SA-11 (2):
+  family: SA
+  name: Developer Security Testing and Evaluation | Threat and Vulnerability Analyses
+  description: |
+    'The organization requires the developer of the information system, system
+    component, or information system service to perform threat and vulnerability
+    analyses and subsequent testing/evaluation of the as-built system,
+    component, or service.'
+
+SA-11 (8):
+  family: SA
+  name: Developer Security Testing and Evaluation | Dynamic Code Analysis
+  description: |
+    'The organization requires the developer of the information system, system
+    component, or information system service to employ dynamic code analysis
+    tools to identify common flaws and document the results of the analysis.'
+
+SA-22:
+  family: SA
+  name: Unsupported System Components
+  description: |
+    'The organization:
+    a.	Replaces information system components when support for the components is no longer available from the developer, vendor, or manufacturer; and
+    b.	Provides justification and documents approval for the continued use of unsupported system components required to satisfy mission/business needs.'
+
+SA-22 (1):
+  family: SA
+  name: Unsupported System Components
+  description: |
+    'The organization provides [Selection (one or more): in-house support;
+    [Assignment: organization-defined support from external providers]] for
+    unsupported information system components.'
+
 SC-1:
   family: SC
   name: System and Communications Protection Policy and Procedures
-SC-10:
-  family: SC
-  name: Network Disconnect
-SC-12:
-  family: SC
-  name: Cryptographic Key Establishment and Management
-SC-12 (2):
-  family: SC
-  name: Cryptographic Key Establishment and Management | Symmetric Keys
-SC-12 (3):
-  family: SC
-  name: Cryptographic Key Establishment and Management | Asymmetric Keys
-SC-13:
-  family: SC
-  name: Cryptographic Protection
-SC-15:
-  family: SC
-  name: Collaborative Computing Devices
-SC-17:
-  family: SC
-  name: Public Key Infrastructure Certificates
-SC-18:
-  family: SC
-  name: Mobile Code
-SC-19:
-  family: SC
-  name: Voice Over Internet Protocol
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	A system and communications protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the system and communications protection policy and associated system and communications protection controls; and
+    b.	Reviews and updates the current:
+      1.	System and communications protection policy [Assignment: organization-defined frequency]; and
+      2.	System and communications protection procedures [Assignment: organization-defined frequency].'
+
 SC-2:
   family: SC
   name: Application Partitioning
-SC-20:
-  family: SC
-  name: Secure Name / Address Resolution Service (Authoritative Source)
-SC-21:
-  family: SC
-  name: Secure Name / Address Resolution Service (Recursive or Caching Resolver)
-SC-22:
-  family: SC
-  name: Architecture and Provisioning for Name / Address Resolution Service
-SC-23:
-  family: SC
-  name: Session Authenticity
-SC-28:
-  family: SC
-  name: Protection of Information At Rest
-SC-28 (1):
-  family: SC
-  name: Protection Of Information At Rest | Cryptographic Protection
-SC-39:
-  family: SC
-  name: Process Isolation
+  description: |
+    'The information system separates user functionality (including user
+    interface services) from information system management functionality.'
+
 SC-4:
   family: SC
   name: Information In Shared Resources
+  description: |
+    'The information system prevents unauthorized and unintended information
+    transfer via shared system resources.'
+
 SC-5:
   family: SC
   name: Denial of Service Protection
+  description: |
+    'The information system protects against or limits the effects of the
+    following types of denial of service attacks: [Assignment:
+    organization-defined types of denial of service attacks or references to
+    sources for such information] by employing [Assignment: organization-defined
+    security safeguards].'
+
 SC-6:
   family: SC
   name: Resource Availability
+  description: |
+    'The information system protects the availability of resources by allocating
+    [Assignment: organization-defined resources] by [Selection (one or more);
+    priority; quota; [Assignment: organization-defined security safeguards]].'
+
 SC-7:
   family: SC
   name: Boundary Protection
-SC-7 (12):
-  family: SC
-  name: Boundary Protection | Host-Based Protection
-SC-7 (13):
-  family: SC
-  name: Boundary Protection | Isolation of Security Tools / Mechanisms / Support Components
-SC-7 (18):
-  family: SC
-  name: Boundary Protection | Fail Secure
+  description: |
+    'The information system:
+    a.	Monitors and controls communications at the external boundary of the system and at key internal boundaries within the system;
+    b.	Implements subnetworks for publicly accessible system components that are [Selection: physically; logically] separated from internal organizational networks; and
+    c.	Connects to external networks or information systems only through managed interfaces consisting of boundary protection devices arranged in accordance with an organizational security architecture.'
+
 SC-7 (3):
   family: SC
   name: Boundary Protection | Access Points
+  description: |
+    'The organization limits the number of external network connections to the
+    information system.'
+
 SC-7 (4):
   family: SC
   name: Boundary Protection | External Telecommunications Services
+  description: |
+    'The organization:
+    SC-7 (4)(a)	Implements a managed interface for each external telecommunication service;
+    SC-7 (4)(b)	Establishes a traffic flow policy for each managed interface;
+    SC-7 (4)(c)	Protects the confidentiality and integrity of the information being transmitted across each interface;
+    SC-7 (4)(d)	Documents each exception to the traffic flow policy with a supporting mission/business need and duration of that need; and
+    SC-7 (4)(e)	Reviews exceptions to the traffic flow policy [Assignment: organization-defined frequency] and removes exceptions that are no longer supported by an explicit mission/business need.'
+
 SC-7 (5):
   family: SC
   name: Boundary Protection | Deny by Default / Allow by Exception
+  description: |
+    'The information system at managed interfaces denies network communications
+    traffic by default and allows network communications traffic by exception
+    (i.e., deny all, permit by exception).'
+
 SC-7 (7):
   family: SC
   name: Boundary Protection | Prevent Split Tunneling for Remote Devices
+  description: |
+    'The information system, in conjunction with a remote device, prevents the
+    device from simultaneously establishing non-remote connections with the
+    system and communicating via some other connection to resources in external
+    networks.'
+
 SC-7 (8):
   family: SC
   name: Boundary Protection | Route Traffic to Authenticated Proxy Servers
+  description: |
+    'The information system routes [Assignment: organization-defined internal
+    communications traffic] to [Assignment: organization-defined external
+    networks] through authenticated proxy servers at managed interfaces.'
+
+SC-7 (12):
+  family: SC
+  name: Boundary Protection | Host-Based Protection
+  description: |
+    'The organization implements [Assignment: organization-defined host-based
+    boundary protection mechanisms] at [Assignment: organization-defined
+    information system components].'
+
+SC-7 (13):
+  family: SC
+  name: Boundary Protection | Isolation of Security Tools / Mechanisms / Support Components
+  description: |
+    'The organization isolates [Assignment: organization-defined information
+    security tools, mechanisms, and support components] from other internal
+    information system components by implementing physically separate
+    subnetworks with managed interfaces to other components of the system.'
+
+SC-7 (18):
+  family: SC
+  name: Boundary Protection | Fail Secure
+  description: |
+    'The information system fails securely in the event of an operational
+    failure of a boundary protection device.'
+
 SC-8:
   family: SC
   name: Transmission Confidentiality and Integrity
+  description: |
+    'The information system protects the [Selection (one or more):
+    confidentiality; integrity] of transmitted information.'
+
 SC-8 (1):
   family: SC
   name: Transmission Confidentiality and Integrity | Cryptographic or Alternate Physical
     Protection
+  description: |
+    'The information system implements cryptographic mechanisms to [Selection
+    (one or more): prevent unauthorized disclosure of information; detect
+    changes to information] during transmission unless otherwise protected by
+    [Assignment: organization-defined alternative physical safeguards].'
+
+SC-10:
+  family: SC
+  name: Network Disconnect
+  description: |
+    'The information system terminates the network connection associated with a
+    communications session at the end of the session or after [Assignment:
+    organization-defined time period] of inactivity.'
+
+SC-12:
+  family: SC
+  name: Cryptographic Key Establishment and Management
+  description: |
+    'The organization establishes and manages cryptographic keys for required
+    cryptography employed within the information system in accordance with
+    [Assignment: organization-defined requirements for key generation,
+    distribution, storage, access, and destruction].'
+
+SC-12 (1):
+  family: SC
+  name: Cryptographic Key Establishment and Management | Availability
+  description: |
+    'The organization maintains availability of information in the event of the
+    loss of cryptographic keys by users.'
+
+SC-12 (2):
+  family: SC
+  name: Cryptographic Key Establishment and Management | Symmetric Keys
+  description: |
+    'The organization produces, controls, and distributes symmetric
+    cryptographic keys using [Selection: NIST FIPS-compliant; NSA-approved] key
+    management technology and processes.'
+
+SC-12 (3):
+  family: SC
+  name: Cryptographic Key Establishment and Management | Asymmetric Keys
+  description: |
+    'The organization produces, controls, and distributes asymmetric
+    cryptographic keys using [Selection: NSA-approved key management technology
+    and processes; approved PKI Class 3 certificates or prepositioned keying
+    material; approved PKI Class 3 or Class 4 certificates and hardware security
+    tokens that protect the user''s private key].'
+
+SC-13:
+  family: SC
+  name: Cryptographic Protection
+  description: |
+    'The information system implements [Assignment: organization-defined
+    cryptographic uses and type of cryptography required for each use] in
+    accordance with applicable federal laws, Executive Orders, directives,
+    policies, regulations, and standards.'
+
+SC-15:
+  family: SC
+  name: Collaborative Computing Devices
+  description: |
+    'The information system:
+    a.	Prohibits remote activation of collaborative computing devices with the following exceptions: [Assignment: organization-defined exceptions where remote activation is to be allowed]; and
+    b.	Provides an explicit indication of use to users physically present at the devices.'
+
+SC-17:
+  family: SC
+  name: Public Key Infrastructure Certificates
+  description: |
+    'The organization issues public key certificates under an [Assignment:
+    organization-defined certificate policy] or obtains public key certificates
+    from an approved service provider.'
+
+SC-18:
+  family: SC
+  name: Mobile Code
+  description: |
+    'The organization:
+    a.	Defines acceptable and unacceptable mobile code and mobile code technologies;
+    b.	Establishes usage restrictions and implementation guidance for acceptable mobile code and mobile code technologies; and
+    c.	Authorizes, monitors, and controls the use of mobile code within the information system.'
+
+SC-19:
+  family: SC
+  name: Voice Over Internet Protocol
+  description: |
+    'The organization:
+    a.	Establishes usage restrictions and implementation guidance for Voice over Internet Protocol (VoIP) technologies based on the potential to cause damage to the information system if used maliciously; and
+    b.	Authorizes, monitors, and controls the use of VoIP within the information system.'
+
+SC-20:
+  family: SC
+  name: Secure Name / Address Resolution Service (Authoritative Source)
+  description: |
+    'The information system:
+    a.	Provides additional data origin authentication and integrity verification artifacts along with the authoritative name resolution data the system returns in response to external name/address resolution queries; and
+    b.	Provides the means to indicate the security status of child zones and (if the child supports secure resolution services) to enable verification of a chain of trust among parent and child domains, when operating as part of a distributed, hierarchical namespace.'
+
+SC-21:
+  family: SC
+  name: Secure Name / Address Resolution Service (Recursive or Caching Resolver)
+  description: |
+    'The information system requests and performs data origin authentication and
+    data integrity verification on the name/address resolution responses the
+    system receives from authoritative sources.'
+
+SC-22:
+  family: SC
+  name: Architecture and Provisioning for Name / Address Resolution Service
+  description: |
+    'The information systems that collectively provide name/address resolution
+    service for an organization are fault-tolerant and implement
+    internal/external role separation.'
+
+SC-23:
+  family: SC
+  name: Session Authenticity
+  description: |
+    'The information system protects the authenticity of communications sessions.'
+
+SC-28:
+  family: SC
+  name: Protection of Information At Rest
+  description: |
+    'The information system protects the [Selection (one or more):
+    confidentiality; integrity] of [Assignment: organization-defined information
+    at rest].'
+
+SC-28 (1):
+  family: SC
+  name: Protection Of Information At Rest | Cryptographic Protection
+  description: |
+    'The information system implements cryptographic mechanisms to prevent
+    unauthorized disclosure and modification of [Assignment:
+    organization-defined information] on [Assignment: organization-defined
+    information system components].'
+
+SC-39:
+  family: SC
+  name: Process Isolation
+  description: |
+    'The information system maintains a separate execution domain for each
+    executing process.'
+
 SI-1:
   family: SI
   name: System and Information Integrity Policy and Procedures
-SI-10:
-  family: SI
-  name: Information Input Validation
-SI-11:
-  family: SI
-  name: Error Handling
-SI-12:
-  family: SI
-  name: Information Handling and Retention
-SI-16:
-  family: SI
-  name: Memory Protection
+  description: |
+    'The organization:
+    a.	Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+      1.	A system and information integrity policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+      2.	Procedures to facilitate the implementation of the system and information integrity policy and associated system and information integrity controls; and
+    b.	Reviews and updates the current:
+      1.	System and information integrity policy [Assignment: organization-defined frequency]; and
+      2.	System and information integrity procedures [Assignment: organization-defined frequency].'
+
 SI-2:
   family: SI
   name: Flaw Remediation
+  description: |
+    'The organization:
+    a.	Identifies, reports, and corrects information system flaws;
+    b.	Tests software and firmware updates related to flaw remediation for effectiveness and potential side effects before installation;
+    c.	Installs security-relevant software and firmware updates within [Assignment: organization-defined time period] of the release of the updates; and
+    d.	Incorporates flaw remediation into the organizational configuration management process.'
+
 SI-2 (2):
   family: SI
   name: Flaw Remediation | Automated Flaw Remediation Status
+  description: |
+    'The organization employs automated mechanisms [Assignment:
+    organization-defined frequency] to determine the state of information system
+    components with regard to flaw remediation.'
+
 SI-2 (3):
   family: SI
   name: Flaw Remediation | Time to Remediate Flaws / Benchmarks for Corrective Actions
+  description: |
+    'The organization:
+    SI-2 (3)(a)	Measures the time between flaw identification and flaw remediation; and
+    SI-2 (3)(b)	Establishes [Assignment: organization-defined benchmarks] for taking corrective actions.'
+
 SI-3:
   family: SI
   name: Malicious Code Protection
+  description: |
+    'The organization:
+    a.	Employs malicious code protection mechanisms at information system entry and exit points to detect and eradicate malicious code;
+    b.	Updates malicious code protection mechanisms whenever new releases are available in accordance with organizational configuration management policy and procedures;
+    c.	Configures malicious code protection mechanisms to:
+      1.	Perform periodic scans of the information system [Assignment: organization-defined frequency] and real-time scans of files from external sources at [Selection (one or more); endpoint; network entry/exit points] as the files are downloaded, opened, or executed in accordance with organizational security policy; and
+      2.	[Selection (one or more): block malicious code; quarantine malicious code; send alert to administrator; [Assignment: organization-defined action]] in response to malicious code detection; and
+    d.	Addresses the receipt of false positives during malicious code detection and eradication and the resulting potential impact on the availability of the information system.'
+
 SI-3 (1):
   family: SI
-  name: Malicious Code Protection | essential Management
+  name: Malicious Code Protection | Central Management
+  description: |
+    'The organization centrally manages malicious code protection mechanisms.'
+
 SI-3 (2):
   family: SI
   name: Malicious Code Protection | Automatic Updates
+  description: |
+    'The information system automatically updates malicious code protection
+    mechanisms.'
+
 SI-3 (7):
   family: SI
   name: Malicious Code Protection | Nonsignature-Based Detection
+  description: |
+    'The information system implements nonsignature-based malicious code
+    detection mechanisms.'
+
 SI-4:
   family: SI
   name: Information System Monitoring
+  description: |
+    'The organization:
+    a.	Monitors the information system to detect:
+      1.	Attacks and indicators of potential attacks in accordance with [Assignment: organization-defined monitoring objectives]; and
+      2.	Unauthorized local, network, and remote connections;
+    b.	Identifies unauthorized use of the information system through [Assignment: organization-defined techniques and methods];
+    c.	Deploys monitoring devices:
+      1.	Strategically within the information system to collect organization-determined essential information; and
+      2.	At ad hoc locations within the system to track specific types of transactions of interest to the organization;
+    d.	Protects information obtained from intrusion-monitoring tools from unauthorized access, modification, and deletion;
+    e.	Heightens the level of information system monitoring activity whenever there is an indication of increased risk to organizational operations and assets, individuals, other organizations, or the Nation based on law enforcement information, intelligence information, or other credible sources of information;
+    f.	Obtains legal opinion with regard to information system monitoring activities in accordance with applicable federal laws, Executive Orders, directives, policies, or regulations; and
+    g.	Provides [Assignment: organization-defined information system monitoring information] to [Assignment: organization-defined personnel or roles] [Selection (one or more): as needed; [Assignment: organization-defined frequency]].'
+
 SI-4 (1):
   family: SI
   name: Information System Monitoring | System-Wide Intrusion Detection System
-SI-4 (16):
-  family: SI
-  name: Information System Monitoring | Correlate Monitoring Information
+  description: |
+    'The organization connects and configures individual intrusion detection
+    tools into an information system-wide intrusion detection system.'
+
 SI-4 (2):
   family: SI
   name: Information System Monitoring | Automated Tools For Real-Time Analysis
-SI-4 (23):
-  family: SI
-  name: Information System Monitoring | Host-Based Devices
+  description: |
+    'The organization employs automated tools to support near real-time analysis
+    of events.'
+
 SI-4 (4):
   family: SI
   name: Information System Monitoring | Inbound and Outbound Communications Traffic
+  description: |
+    'The information system monitors inbound and outbound communications traffic
+    [Assignment: organization-defined frequency] for unusual or unauthorized
+    activities or conditions.'
+
 SI-4 (5):
   family: SI
   name: Information System Monitoring | System-Generated Alerts
+  description: |
+    'The information system alerts [Assignment: organization-defined personnel
+    or roles] when the following indications of compromise or potential
+    compromise occur: [Assignment: organization-defined compromise indicators].'
+
 SI-4(14):
   family: SI
   name: Information System Monitoring | Wireless Intrusion Detection
+  description: |
+    'The organization employs a wireless intrusion detection system to identify
+    rogue wireless devices and to detect attack attempts and potential
+    compromises/breaches to the information system.'
+
+SI-4 (16):
+  family: SI
+  name: Information System Monitoring | Correlate Monitoring Information
+  description: |
+    'The organization correlates information from monitoring tools employed
+    throughout the information system.'
+
+SI-4 (23):
+  family: SI
+  name: Information System Monitoring | Host-Based Devices
+  description: |
+    'The organization implements [Assignment: organization-defined host-based
+    monitoring mechanisms] at [Assignment: organization-defined information
+    system components].'
+
 SI-5:
   family: SI
   name: Security Alerts, Advisories, and Directives
+  description: |
+    'The organization:
+    a.	Receives information system security alerts, advisories, and directives from [Assignment: organization-defined external organizations] on an ongoing basis;
+    b.	Generates internal security alerts, advisories, and directives as deemed necessary;
+    c.	Disseminates security alerts, advisories, and directives to: [Selection (one or more): [Assignment: organization-defined personnel or roles]; [Assignment: organization-defined elements within the organization]; [Assignment: organization-defined external organizations]]; and
+    d.	Implements security directives in accordance with established time frames, or notifies the issuing organization of the degree of noncompliance.'
+
 SI-6:
   family: SI
   name: Security Function Verification
+  description: |
+    'The information system:
+    a.	Verifies the correct operation of [Assignment: organization-defined security functions];
+    b.	Performs this verification [Selection (one or more): [Assignment: organization-defined system transitional states]; upon command by user with appropriate privilege; [Assignment: organization-defined frequency]];
+    c.	Notifies [Assignment: organization-defined personnel or roles] of failed security verification tests; and
+    d.	[Selection (one or more): shuts the information system down; restarts the information system; [Assignment: organization-defined alternative action(s)]] when anomalies are discovered.'
+
 SI-7:
   family: SI
   name: Software, Firmware, and Information Integrity
+  description: |
+    'The organization employs integrity verification tools to detect
+    unauthorized changes to [Assignment: organization-defined software,
+    firmware, and information].'
+
 SI-7 (1):
   family: SI
   name: Software, Firmware, and Information Integrity | Integrity Checks
+  description: |
+    'The information system performs an integrity check of [Assignment:
+    organization-defined software, firmware, and information] [Selection (one or
+    more): at startup; at [Assignment: organization-defined transitional states
+    or security-relevant events]; [Assignment: organization-defined
+    frequency]].'
+
 SI-7 (7):
   family: SI
   name: Software, Firmware, and Information Integrity | Integration of Detection and
     Response
+  description: |
+    'The organization incorporates the detection of unauthorized [Assignment:
+    organization-defined security-relevant changes to the information system]
+    into the organizational incident response capability.'
+
 SI-8:
   family: SI
   name: Spam Protection
+  description: |
+    'The organization:
+    a.	Employs spam protection mechanisms at information system entry and exit points to detect and take action on unsolicited messages; and
+    b.	Updates spam protection mechanisms when new releases are available in accordance with organizational configuration management policy and procedures.'
+
 SI-8 (1):
   family: SI
   name: Spam Protection | essential Management
+  description: |
+    'The organization centrally manages spam protection mechanisms.'
+
 SI-8 (2):
   family: SI
   name: Spam Protection | Automatic Updates
+  description: |
+    'The information system automatically updates spam protection mechanisms.'
+
+SI-10:
+  family: SI
+  name: Information Input Validation
+  description: |
+    'The information system checks the validity of [Assignment:
+    organization-defined information inputs].'
+
+SI-11:
+  family: SI
+  name: Error Handling
+  description: |
+    'The information system:
+    a.	Generates error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries; and
+    b.	Reveals error messages only to [Assignment: organization-defined personnel or roles].'
+
+SI-12:
+  family: SI
+  name: Information Handling and Retention
+  description: |
+    'The organization handles and retains information within the information
+    system and information output from the system in accordance with applicable
+    federal laws, Executive Orders, directives, policies, regulations,
+    standards, and operational requirements.'
+
+SI-16:
+  family: SI
+  name: Memory Protection
+  description: |
+    'The information system implements [Assignment: organization-defined
+    security safeguards] to protect its memory from unauthorized code
+    execution.'
+
 name: NIST-800-53

--- a/lib/common/control.go
+++ b/lib/common/control.go
@@ -9,4 +9,5 @@ package common
 type Control interface {
 	GetName() string
 	GetFamily() string
+	GetDescription() string
 }

--- a/lib/common/mocks/Control.go
+++ b/lib/common/mocks/Control.go
@@ -36,4 +36,18 @@ func (_m *Control) GetName() string {
 	return r0
 }
 
+// GetDescription provides a mock function with given fields:
+func (_m *Control) GetDescription() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 var _ common.Control = (*Control)(nil)

--- a/lib/standards/standard_test.go
+++ b/lib/standards/standard_test.go
@@ -1,10 +1,11 @@
 package standards
 
 import (
-	"github.com/opencontrol/compliance-masonry/lib/common"
-	v1_0_0 "github.com/opencontrol/compliance-masonry/lib/standards/versions/1_0_0"
 	"path/filepath"
 	"testing"
+
+	"github.com/opencontrol/compliance-masonry/lib/common"
+	v1_0_0 "github.com/opencontrol/compliance-masonry/lib/standards/versions/1_0_0"
 )
 
 type v1standardsTest struct {
@@ -15,7 +16,7 @@ type v1standardsTest struct {
 
 var standardsTests = []v1standardsTest{
 	// Check loading a standard that has 326 controls
-	{filepath.Join("..", "..", "fixtures", "opencontrol_fixtures", "standards", "NIST-800-53.yaml"), v1_0_0.Standard{Name: "NIST-800-53"}, 326},
+	{filepath.Join("..", "..", "fixtures", "opencontrol_fixtures", "standards", "NIST-800-53.yaml"), v1_0_0.Standard{Name: "NIST-800-53"}, 328},
 	// Check loading a standard that has 258 controls
 	{filepath.Join("..", "..", "fixtures", "opencontrol_fixtures", "standards", "PCI-DSS-MAY-2015.yaml"), v1_0_0.Standard{Name: "PCI-DSS-MAY-2015"}, 258},
 }

--- a/lib/standards/standard_test.go
+++ b/lib/standards/standard_test.go
@@ -15,7 +15,7 @@ type v1standardsTest struct {
 }
 
 var standardsTests = []v1standardsTest{
-	// Check loading a standard that has 326 controls
+	// Check loading a standard that has 328 controls
 	{filepath.Join("..", "..", "fixtures", "opencontrol_fixtures", "standards", "NIST-800-53.yaml"), v1_0_0.Standard{Name: "NIST-800-53"}, 328},
 	// Check loading a standard that has 258 controls
 	{filepath.Join("..", "..", "fixtures", "opencontrol_fixtures", "standards", "PCI-DSS-MAY-2015.yaml"), v1_0_0.Standard{Name: "PCI-DSS-MAY-2015"}, 258},

--- a/lib/standards/versions/1_0_0/standard.go
+++ b/lib/standards/versions/1_0_0/standard.go
@@ -1,16 +1,18 @@
 package standard
 
 import (
-	"github.com/opencontrol/compliance-masonry/lib/common"
 	"sort"
+
+	"github.com/opencontrol/compliance-masonry/lib/common"
 	"vbom.ml/util/sortorder"
 )
 
 // Control struct stores data on a specific security requirement
 // Schema info: https://github.com/opencontrol/schemas#standards-documentation
 type Control struct {
-	Family string `yaml:"family" json:"family"`
-	Name   string `yaml:"name" json:"name"`
+	Family      string `yaml:"family" json:"family"`
+	Name        string `yaml:"name" json:"name"`
+	Description string `yaml:"description" json:"description"`
 }
 
 // Standard struct is a collection of security requirements
@@ -57,4 +59,9 @@ func (control Control) GetFamily() string {
 // GetName returns the string representation of the control.
 func (control Control) GetName() string {
 	return control.Name
+}
+
+// GetDescription returns the string description of the control.
+func (control Control) GetDescription() string {
+	return control.Description
 }

--- a/lib/standards/versions/1_0_0/standard_test.go
+++ b/lib/standards/versions/1_0_0/standard_test.go
@@ -60,7 +60,7 @@ func TestControlOrder(t *testing.T) {
 }
 
 func TestGetters(t *testing.T) {
-	st := Standard{Name: "test", Controls: map[string]Control{"3": Control{Name: "controlName", Family: "controlFamily"}, "2": Control{}, "1": Control{}}}
+	st := Standard{Name: "test", Controls: map[string]Control{"3": Control{Name: "controlName", Family: "controlFamily", Description: "controlDescription"}, "2": Control{}, "1": Control{}}}
 	if st.GetName() != "test" {
 		t.Errorf("Expected standard name test. Actual %s", st.GetName())
 	}
@@ -74,5 +74,8 @@ func TestGetters(t *testing.T) {
 	}
 	if control.GetFamily() != "controlFamily" {
 		t.Errorf("Expected control family 'controlFamily'. Actual %s", control.GetFamily())
+	}
+	if control.GetDescription() != "controlDescription" {
+		t.Errorf("Expected control family 'controlDescription'. Actual %s", control.GetDescription())
 	}
 }


### PR DESCRIPTION
Related:
https://github.com/opencontrol/schemas/pull/56
https://github.com/opencontrol/schemas/issues/60

Based on a slack conversation with @anweiss, this PR adds compliance-masonry support for a "description" field for standards, based on the v1.0.0 schema.  [NIST-800-53 standards](https://github.com/opencontrol/NIST-800-53-Standards/blob/master/NIST-800-53.yaml) have already added the field as an example.

This PR also adds the description to the top of each standard page in the generated gitbook documentation.  For example:

![image](https://user-images.githubusercontent.com/1859958/28189007-2a7e7990-67f2-11e7-8734-9dd53a3c2f06.png)


