### PR TITLE
Replaced 3 calls to go-utils/ufs with metaleap/go-util 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -33,37 +33,59 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/go-utils/ufs"
-  packages = ["."]
-  revision = "759211ccbbfc380b7356c038dbb3667251f6b7b3"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/metaleap/go-util-misc"
-  packages = ["."]
-  revision = "c53f803886d3a520c369beb2368914d853389f30"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/metaleap/go-util-slice"
-  packages = ["."]
-  revision = "fb69df90f7992e63a8959323a08a85aaba012564"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/metaleap/go-util-str"
-  packages = ["."]
-  revision = "ea3253c93490d3bbb0ad77670e2ad712e717ae1a"
+  name = "github.com/metaleap/go-util"
+  packages = [
+    ".",
+    "fs",
+    "slice",
+    "str"
+  ]
+  revision = "7d8694c67c9b2cbdd095f1430ab6807e1feda0f0"
 
 [[projects]]
   name = "github.com/onsi/ginkgo"
-  packages = [".","config","extensions/table","internal/codelocation","internal/containernode","internal/failer","internal/leafnodes","internal/remote","internal/spec","internal/spec_iterator","internal/specrunner","internal/suite","internal/testingtproxy","internal/writer","reporters","reporters/stenographer","reporters/stenographer/support/go-colorable","reporters/stenographer/support/go-isatty","types"]
+  packages = [
+    ".",
+    "config",
+    "extensions/table",
+    "internal/codelocation",
+    "internal/containernode",
+    "internal/failer",
+    "internal/leafnodes",
+    "internal/remote",
+    "internal/spec",
+    "internal/spec_iterator",
+    "internal/specrunner",
+    "internal/suite",
+    "internal/testingtproxy",
+    "internal/writer",
+    "reporters",
+    "reporters/stenographer",
+    "reporters/stenographer/support/go-colorable",
+    "reporters/stenographer/support/go-isatty",
+    "types"
+  ]
   revision = "77a8c1e5c40d6bb6c5eb4dd4bdce9763564f6298"
   version = "v1.3.1"
 
 [[projects]]
   name = "github.com/onsi/gomega"
-  packages = [".","format","gbytes","gexec","internal/assertion","internal/asyncassertion","internal/oraclematcher","internal/testingtsupport","matchers","matchers/support/goraph/bipartitegraph","matchers/support/goraph/edge","matchers/support/goraph/node","matchers/support/goraph/util","types"]
+  packages = [
+    ".",
+    "format",
+    "gbytes",
+    "gexec",
+    "internal/assertion",
+    "internal/asyncassertion",
+    "internal/oraclematcher",
+    "internal/testingtsupport",
+    "matchers",
+    "matchers/support/goraph/bipartitegraph",
+    "matchers/support/goraph/edge",
+    "matchers/support/goraph/node",
+    "matchers/support/goraph/util",
+    "types"
+  ]
   revision = "334b8f472b3af5d541c5642701c1e29e2126f486"
   version = "v1.1.0"
 
@@ -81,7 +103,10 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","mock"]
+  packages = [
+    "assert",
+    "mock"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -124,6 +149,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "16d0a94d866c136228b6f2ca0d50fe73b4a8e468fc887440f9f5cadf78eb8827"
+  inputs-digest = "a2c8ad308175500998e63ddc257a2528583679242b33fb8c686e5a27864193bd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/go-utils/ufs"
+  name = "github.com/metaleap/go-util"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"

--- a/tools/fs/fs.go
+++ b/tools/fs/fs.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/go-utils/ufs"
+  metaleapfs "github.com/metaleap/go-util/fs"
 )
 
 // Util is an interface for helper file system utilities.
@@ -37,13 +37,13 @@ func (fs OSUtil) OpenAndReadFile(file string) ([]byte, error) {
 
 // CopyAll copies recursively from source to destination
 func (fs OSUtil) CopyAll(source string, destination string) error {
-	return ufs.CopyAll(source, destination, nil)
+	return metaleapfs.CopyAll(source, destination, nil, "")
 }
 
 // Copy copies one file from source to destination
 func (fs OSUtil) Copy(source string, destination string) error {
 	log.Printf("source %s dest %s\n", source, destination)
-	return ufs.CopyFile(source, destination)
+	return metaleapfs.CopyFile(source, destination)
 }
 
 // TempDir creates a temp directory that the user is responsible for cleaning up
@@ -53,7 +53,7 @@ func (fs OSUtil) TempDir(dir string, prefix string) (string, error) {
 
 // Mkdirs ensures that the directory is created.
 func (fs OSUtil) Mkdirs(dir string) error {
-	return ufs.EnsureDirExists(dir)
+	return metaleapfs.EnsureDirExists(dir)
 }
 
 // AppendOrCreate adds text to file if it exists otherwise it creates a new

--- a/tools/fs/fs.go
+++ b/tools/fs/fs.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-  metaleapfs "github.com/metaleap/go-util/fs"
+	metaleapfs "github.com/metaleap/go-util/fs"
 )
 
 // Util is an interface for helper file system utilities.


### PR DESCRIPTION
Replaced the 3 calls to go-utils/ufs with metalapp/go-util.
Only difference was adding an empty string in call to CopyAll for the 4th skipFileSuffix parameter.
Renamed the import to meatleapfs to prevent overlaps.

Complied and Tested on macOS High Sierra 10.13.2

∴ go version
go version go1.9.3 darwin/amd64