### PR TITLE
Add contextdir for multi-directory git handling

### DIFF
--- a/commands/get/resources/getter.go
+++ b/commands/get/resources/getter.go
@@ -184,6 +184,12 @@ func (g *vcsAndLocalFSGetter) GetRemoteResources(destination string, subfolder s
 
 		// Clone repo
 		log.Printf("Attempting to clone %v into %s\n", entry, tempPath)
+
+		// If contextdir is defined, switch to that dir for content
+		if entry.GetContextDir() != "" {
+			tempPath = filepath.Join(tempPath, entry.GetContextDir())
+	        }
+
 		err := g.Downloader.DownloadRepo(entry, tempPath)
 		if err != nil {
 			return err

--- a/commands/get/resources/getter_test.go
+++ b/commands/get/resources/getter_test.go
@@ -144,6 +144,7 @@ func createMockRemoteSource() common.RemoteSource {
 	// Setup remoteSource mock
 	remoteSource := new(mocks.RemoteSource)
 	remoteSource.On("GetURL").Return("")
+	remoteSource.On("GetContextDir").Return("")
 	remoteSource.On("GetConfigFile").Return("")
 	return remoteSource
 }

--- a/lib/common/mocks/RemoteSource.go
+++ b/lib/common/mocks/RemoteSource.go
@@ -50,4 +50,18 @@ func (_m *RemoteSource) GetURL() string {
 	return r0
 }
 
+// GetContextDir provides a mock function with given fields:
+func (_m *RemoteSource) GetContextDir() string {
+        ret := _m.Called()
+
+        var r0 string
+        if rf, ok := ret.Get(0).(func() string); ok {
+                r0 = rf()
+        } else {
+                r0 = ret.Get(0).(string)
+        }
+
+        return r0
+}
+
 var _ common.RemoteSource = (*RemoteSource)(nil)

--- a/lib/common/opencontrol.go
+++ b/lib/common/opencontrol.go
@@ -27,11 +27,14 @@ type OpenControl interface {
 //
 // GetURL returns the URL of the resource.
 //
+// GetContextDir returns the specific directory containing the OpenControl content.
+//
 // GetRevision returns the specific revision of the resource.
 //
 // GetConfigFile returns the config file to look at once the resource is downloaded.
 type RemoteSource interface {
 	GetURL() string
+	GetContextDir() string
 	GetRevision() string
 	GetConfigFile() string
 }

--- a/lib/opencontrol/versions/1.0.0/opencontrol.go
+++ b/lib/opencontrol/versions/1.0.0/opencontrol.go
@@ -38,6 +38,7 @@ type Metadata struct {
 type VCSEntry struct {
 	URL      string `yaml:"url"`
 	Revision string `yaml:"revision"`
+	ContextDir string `yaml:"contextdir"`
 	Path     string `yaml:"path"`
 }
 
@@ -102,4 +103,9 @@ func (e VCSEntry) GetRevision() string {
 // GetURL returns the URL of the vcs resource.
 func (e VCSEntry) GetURL() string {
 	return e.URL
+}
+
+// GetContextDir returns the dir containing content in the vcs resource.
+func (e VCSEntry) GetContextDir() string {
+        return e.ContextDir
 }


### PR DESCRIPTION
This allows for multiple opencontrol directories in a single git repository.