### PR TITLE
Update tests

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,4 +1,4 @@
 ## Circle CI Scripts
 
 Call these scripts from the root of the repository
-- `circleci/coverage.sh # example`
+- `./.circleci/coverage.sh # example`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,19 +13,10 @@ jobs:
       - run:
           name: Build the program
           command: go build
-
-      - run:
-          name: Download test dependencies
-          command: |
-            go get -u \
-              github.com/golang/dep/cmd/dep \
-              github.com/axw/gocov/gocov \
-              github.com/kisielk/errcheck \
-              github.com/mattn/goveralls \
-              golang.org/x/tools/cmd/cover
       - run:
           name: Run tests
           command: ./.circleci/coverage.sh
       - run:
-          name: Check for unhandled errors
-          command: errcheck
+          name: Send results to Codecov
+          shell: /bin/bash
+          command: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,18 +3,13 @@ jobs:
   build:
     working_directory: /go/src/github.com/opencontrol/compliance-masonry
     docker:
-      - image: golang:1.8-alpine
+      - image: golang:1.10-alpine
     steps:
       - run:
           name: Install Git
           command: apk add --no-cache bash gcc git musl-dev
       - checkout
 
-      - run:
-          name: Install dependencies
-          command: |
-            go get -u github.com/golang/dep/cmd/dep
-            dep ensure
       - run:
           name: Build the program
           command: go build
@@ -30,7 +25,7 @@ jobs:
               golang.org/x/tools/cmd/cover
       - run:
           name: Run tests
-          command: ./circleci/coverage.sh
+          command: ./.circleci/coverage.sh
       - run:
           name: Check for unhandled errors
           command: errcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - run:
           name: Install Git
-          command: apk add --no-cache bash gcc git musl-dev
+          command: apk add --no-cache bash gcc git musl-dev curl
       - checkout
 
       - run:

--- a/.circleci/coverage.sh
+++ b/.circleci/coverage.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -x
 set -e
 
 cov_file=/tmp/coverage.txt

--- a/.circleci/coverage.sh
+++ b/.circleci/coverage.sh
@@ -6,7 +6,7 @@ set -e
 cov_file=/tmp/coverage.txt
 
 # Get the list of packages.
-pkgs=`go list ./... | grep -v vendor`
+pkgs=`go list ./...`
 
 echo "mode: count" > $cov_file
 for pkg in $pkgs

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,5 @@
-engines:
+version: "2"
+plugins:
   fixme:
     enabled: true
   gofmt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,9 @@ install:
 
     go env
 
-    go get github.com/golang/dep/cmd/dep github.com/Masterminds/glide
+    go get github.com/Masterminds/glide
 
     set PATH=%PATH%;%GOPATH%\bin
-
-    dep ensure
 build_script:
 - cmd: go build
 test_script:

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,7 +42,7 @@ This should print out usage documentation.
 # Get test dependencies
 go get -t ./...
 # Run tests
-go test $(go list ./... | grep -v vendor)
+go test $(go list ./...)
 ```
 
 ## Creating binaries

--- a/lib/opencontrol/parse_test.go
+++ b/lib/opencontrol/parse_test.go
@@ -119,7 +119,7 @@ dependencies:
 		It("should unsuccessfully parse", func() {
 			parser := YAMLParser{}
 			opencontrol, err := parser.Parse(data)
-			assert.Equal(GinkgoT(), "Unable to parse yaml data - yaml: line 1: found character that cannot start any token", err.Error())
+			assert.Equal(GinkgoT(), "Unable to parse yaml data - yaml: line 2: found character that cannot start any token", err.Error())
 			assert.Nil(GinkgoT(), opencontrol)
 		})
 	})

--- a/release.sh
+++ b/release.sh
@@ -4,5 +4,5 @@ set -x
 
 # run `go test` outside of goxc since there wasn't a clean way to ignore the vendor/ directory otherwise
 # https://github.com/laher/goxc/issues/99
-go test $(go list ./... | grep -v vendor)
+go test $(go list ./...)
 $GOPATH/bin/goxc "$@"


### PR DESCRIPTION
- Remove dotdotdot in go tests for go-1.9 compatibility
- Update circleci tests to go-1.10 as AppVeyor tests already do this
- Update the circleci config to match latest configurations
- Remove Go dependencies as test should fail if dependency is missing from `vendor/` folder
- Fixes #262