### PR TITLE
Rename executable to masonry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,11 @@ jobs:
       - checkout
 
       - run:
-          name: Build the program
+          name: Build the compliance-masonry program
           command: go build cmd/compliance-masonry/compliance-masonry.go
+      - run:
+          name: Build the masonry program
+          command: go build cmd/masonry/masonry.go
       - run:
           name: Run tests
           command: ./.circleci/coverage.sh

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ GOFMT ?= gofmt
 GOLINT ?= golint
 EPOCH_TEST_COMMIT ?= 1cc5a27
 PROJECT := github.com/opencontrol/compliance-masonry
-PROGNAME ?= compliance-masonry
+PROGNAME ?= masonry
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 PREFIX ?= ${DESTDIR}/usr/local
 BINDIR ?= ${PREFIX}/bin
-DATAROOTDIR ?= ${PREFIX}/share/compliance-masonry
+DATAROOTDIR ?= ${PREFIX}/share/masonry
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 
@@ -36,10 +36,12 @@ DEBUGFLAGS ?= -gcflags="-N -l"
 endif
 
 build:
-	$(GO) build \
-		$(DEBUGFLAGS) \
+	$(GO) build $(DEBUGFLAGS) \
 		-o $(BUILD_DIR)/$(PROGNAME) \
-		cmd/compliance-masonry/compliance-masonry.go
+		cmd/masonry/masonry.go
+	$(GO) build $(DEBUGFLAGS) \
+                -o $(BUILD_DIR)/compliance-masonry \
+                cmd/compliance-masonry/compliance-masonry.go
 
 all: build
 
@@ -48,9 +50,12 @@ platforms:
 		GOOS="`echo $$platform | cut -d"/" -f1`"; \
 		GOARCH="`echo $$platform | cut -d"/" -f2`"; \
 		output_name="$(BUILD_DIR)/$$GOOS-$$GOARCH/$(PROGNAME)"; \
+		legacy_name="$(BUILD_DIR)/$$GOOS-$$GOARCH/compliance-masonry"; \
 		[ $$GOOS = "windows" ] && output_name="$$output_name.exe"; \
+		[ $$GOOS = "windows" ] && legacy_name="$$legacy_name.exe"; \
 		echo "Building $(PROGNAME) version $(VERSION) for $$GOOS on $$GOARCH"; \
-		GOOS=$$GOOS GOARCH=$$GOARCH $(GO) build -o $$output_name cmd/compliance-masonry/compliance-masonry.go; \
+		GOOS=$$GOOS GOARCH=$$GOARCH $(GO) build -o $$output_name cmd/masonry/masonry.go; \
+		GOOS=$$GOOS GOARCH=$$GOARCH $(GO) build -o $$legacy_name cmd/compliance-masonry/compliance-masonry.go; \
 		[ -d $(BUILD_DIR)/$$GOOS-$$GOARCH/ ] && cp {LICENSE.md,README.md} $(BUILD_DIR)/$$GOOS-$$GOARCH/; \
 	done
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,5 +18,6 @@ install:
     set PATH=%PATH%;%GOPATH%\bin
 build_script:
 - cmd: go build cmd/compliance-masonry/compliance-masonry.go
+- cmd: go build cmd/masonry/masonry.go
 test_script:
 - cmd: FOR /F %%A IN ('glide novendor') DO go test -v %%A || exit /b 1

--- a/cmd/compliance-masonry/compliance-masonry.go
+++ b/cmd/compliance-masonry/compliance-masonry.go
@@ -1,14 +1,39 @@
 package main
 
 import (
+	"fmt"
+	"log"
 	"os"
-
-	"github.com/opencontrol/compliance-masonry/pkg/cmd/masonry"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 )
 
 func main() {
-	if err := masonry.Run(); err != nil {
-		os.Exit(1)
+	var binary string
+	var cmd *exec.Cmd
+
+	if runtime.GOOS == "windows" {
+		binary = "masonry.exe"
+	} else {
+		binary = "masonry"
 	}
-	os.Exit(0)
+
+	prog, err := filepath.Abs(filepath.Join(binary))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	args := os.Args
+	if len(args) > 1 {
+		cmd = exec.Command(prog, args[1:]...)
+	} else {
+		cmd = exec.Command(prog)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		//do nothing
+	}
+	fmt.Printf("%s\n", output)
 }

--- a/cmd/masonry/masonry.go
+++ b/cmd/masonry/masonry.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"os"
+
+	"github.com/opencontrol/compliance-masonry/pkg/cmd/masonry"
+)
+
+func main() {
+	if err := masonry.Run(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/cmd/masonry/masonry_suit_test.go
+++ b/cmd/masonry/masonry_suit_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestComplianceMasonryGo(t *testing.T) {
+func TestMasonryGo(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ComplianceMasonryGo Suite")
 }

--- a/cmd/masonry/masonry_test.go
+++ b/cmd/masonry/masonry_test.go
@@ -8,8 +8,8 @@ import (
 
 var usage = `
 Usage:
-  compliance-masonry [flags]
-  compliance-masonry [command]
+  masonry [flags]
+  masonry [command]
 
 Available Commands:
   diff        Compliance Diff Gap Analysis
@@ -18,7 +18,7 @@ Available Commands:
   help        Help about any command
 
 Flags:
-  -h, --help      help for compliance-masonry
+  -h, --help      help for masonry
       --verbose   Run with verbosity
   -v, --version   Print the version
 `

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -84,7 +84,7 @@ func cleanupOpencontrolWorkspace() {
 }
 
 func Masonry(args ...string) *Session {
-	path, err := Build("github.com/opencontrol/compliance-masonry/cmd/compliance-masonry")
+	path, err := Build("github.com/opencontrol/compliance-masonry/cmd/masonry")
 	Expect(err).NotTo(HaveOccurred())
 	return createCommand(path, args...)
 }

--- a/pkg/cmd/masonry/cmd.go
+++ b/pkg/cmd/masonry/cmd.go
@@ -25,7 +25,7 @@ var Version bool
 // Add new commands/subcommands for new verbs in this function
 func NewMasonryCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds := &cobra.Command{
-		Use:   "compliance-masonry",
+		Use:   "masonry",
 		Short: "OpenControl CLI Tool",
 		Long: `Compliance Masonry is a command-line interface (CLI) that
 allows users to construct certification documentation using

--- a/pkg/tests/test_masonry.go
+++ b/pkg/tests/test_masonry.go
@@ -13,7 +13,7 @@ import (
 // Masonry is used to launch tests on the CLI
 func Masonry(args ...string) *gexec.Session {
 	RegisterFailHandler(Fail)
-	path, err := gexec.Build("github.com/opencontrol/compliance-masonry/cmd/compliance-masonry")
+	path, err := gexec.Build("github.com/opencontrol/compliance-masonry/cmd/masonry")
 	Expect(err).NotTo(HaveOccurred())
 	cmd := exec.Command(path, args...)
 	stdin, err := cmd.StdinPipe()


### PR DESCRIPTION
- Create a new compliance-masonry executable for legacy uses
- New masonry.go is now the primary program naming
- Fixes #177