### PR TITLE
Exclude mocks/ directories from codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -17,3 +17,4 @@ ratings:
 exclude_paths:
 - test/
 - vendor/
+- "**/mocks/"


### PR DESCRIPTION
- Files in mocks/ directories are autogenerated so we shouldn't care about evaluating code quality.