### PR TITLE
Add License reference to code

### DIFF
--- a/cmd/compliance-masonry/compliance-masonry.go
+++ b/cmd/compliance-masonry/compliance-masonry.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package main
 
 import (

--- a/cmd/masonry/masonry.go
+++ b/cmd/masonry/masonry.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package main
 
 import (

--- a/cmd/masonry/masonry_suit_test.go
+++ b/cmd/masonry/masonry_suit_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package main_test
 
 import (

--- a/cmd/masonry/masonry_test.go
+++ b/cmd/masonry/masonry_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package main_test
 
 import (

--- a/examples/example.go
+++ b/examples/example.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package main
 
 import (

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package main
 
 import (

--- a/examples/exampleplugin_suite_test.go
+++ b/examples/exampleplugin_suite_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package main_test
 
 import (

--- a/pkg/cli/clierrors/errors.go
+++ b/pkg/cli/clierrors/errors.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package clierrors
 
 import (

--- a/pkg/cli/diff/diff.go
+++ b/pkg/cli/diff/diff.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package diff
 
 import (

--- a/pkg/cli/diff/diff_suite_test.go
+++ b/pkg/cli/diff/diff_suite_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package diff_test
 
 import (

--- a/pkg/cli/diff/diff_test.go
+++ b/pkg/cli/diff/diff_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package diff_test
 
 import (

--- a/pkg/cli/diff/inventory.go
+++ b/pkg/cli/diff/inventory.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package diff
 
 import (

--- a/pkg/cli/diff/inventory_test.go
+++ b/pkg/cli/diff/inventory_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package diff_test
 
 import (

--- a/pkg/cli/docs/docs.go
+++ b/pkg/cli/docs/docs.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package docs
 
 import (

--- a/pkg/cli/docs/docs_suite_test.go
+++ b/pkg/cli/docs/docs_suite_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package docs_test
 
 import (

--- a/pkg/cli/docs/docs_test.go
+++ b/pkg/cli/docs/docs_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package docs_test
 
 import (

--- a/pkg/cli/docs/gitbook/gitbook.go
+++ b/pkg/cli/docs/gitbook/gitbook.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package gitbook
 
 import (

--- a/pkg/cli/docs/gitbook/gitbookCertification.go
+++ b/pkg/cli/docs/gitbook/gitbookCertification.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package gitbook
 
 import (

--- a/pkg/cli/docs/gitbook/gitbookCertification_test.go
+++ b/pkg/cli/docs/gitbook/gitbookCertification_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package gitbook
 
 import (

--- a/pkg/cli/docs/gitbook/gitbookComponents.go
+++ b/pkg/cli/docs/gitbook/gitbookComponents.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package gitbook
 
 import (

--- a/pkg/cli/docs/gitbook/gitbookComponents_test.go
+++ b/pkg/cli/docs/gitbook/gitbookComponents_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package gitbook
 
 import (

--- a/pkg/cli/docs/gitbook/gitbookSummaries.go
+++ b/pkg/cli/docs/gitbook/gitbookSummaries.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package gitbook
 
 import (

--- a/pkg/cli/docs/gitbook/gitbookSummaries_test.go
+++ b/pkg/cli/docs/gitbook/gitbookSummaries_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package gitbook
 
 import (

--- a/pkg/cli/docs/gitbook/gitbook_test.go
+++ b/pkg/cli/docs/gitbook/gitbook_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package gitbook
 
 import (

--- a/pkg/cli/export/export.go
+++ b/pkg/cli/export/export.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package export
 
 import (

--- a/pkg/cli/export/exportFormat.go
+++ b/pkg/cli/export/exportFormat.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package export
 
 import (

--- a/pkg/cli/export/export_config.go
+++ b/pkg/cli/export/export_config.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package export
 
 import (

--- a/pkg/cli/export/export_flatten.go
+++ b/pkg/cli/export/export_flatten.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package export
 
 import (

--- a/pkg/cli/export/export_outputFormat.go
+++ b/pkg/cli/export/export_outputFormat.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package export
 
 import (

--- a/pkg/cli/export/export_suite_test.go
+++ b/pkg/cli/export/export_suite_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package export_test
 
 import (

--- a/pkg/cli/export/export_test.go
+++ b/pkg/cli/export/export_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package export_test
 
 import (

--- a/pkg/cli/export/export_utility.go
+++ b/pkg/cli/export/export_utility.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package export
 
 import (

--- a/pkg/cli/get/get.go
+++ b/pkg/cli/get/get.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package get
 
 import (

--- a/pkg/cli/get/resources/downloader.go
+++ b/pkg/cli/get/resources/downloader.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package resources
 
 import (

--- a/pkg/cli/get/resources/downloader_test.go
+++ b/pkg/cli/get/resources/downloader_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package resources
 
 import (

--- a/pkg/cli/get/resources/getter.go
+++ b/pkg/cli/get/resources/getter.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package resources
 
 import (

--- a/pkg/cli/get/resources/getter_test.go
+++ b/pkg/cli/get/resources/getter_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package resources
 
 import (

--- a/pkg/cli/get/resources/resources_suite_test.go
+++ b/pkg/cli/get/resources/resources_suite_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package resources
 
 import (

--- a/pkg/cmd/masonry/cmd.go
+++ b/pkg/cmd/masonry/cmd.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package masonry
 
 import (

--- a/pkg/cmd/masonry/masonry.go
+++ b/pkg/cmd/masonry/masonry.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package masonry
 
 import (

--- a/pkg/lib/certifications.go
+++ b/pkg/lib/certifications.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package lib
 
 import (

--- a/pkg/lib/certifications/certification.go
+++ b/pkg/lib/certifications/certification.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package certifications
 
 import (

--- a/pkg/lib/certifications/certification_test.go
+++ b/pkg/lib/certifications/certification_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package certifications_test
 
 import (

--- a/pkg/lib/certifications/versions/1_0_0/certification.go
+++ b/pkg/lib/certifications/versions/1_0_0/certification.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package certification
 
 import (

--- a/pkg/lib/certifications/versions/1_0_0/certification_test.go
+++ b/pkg/lib/certifications/versions/1_0_0/certification_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package certification_test
 
 import (

--- a/pkg/lib/common/certification.go
+++ b/pkg/lib/common/certification.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common
 
 //go:generate mockery -name Certification

--- a/pkg/lib/common/component.go
+++ b/pkg/lib/common/component.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common
 
 import "github.com/blang/semver"

--- a/pkg/lib/common/control.go
+++ b/pkg/lib/common/control.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common
 
 //go:generate mockery -name Control

--- a/pkg/lib/common/errors.go
+++ b/pkg/lib/common/errors.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common
 
 import "errors"

--- a/pkg/lib/common/opencontrol.go
+++ b/pkg/lib/common/opencontrol.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common
 
 //go:generate mockery -name OpenControl

--- a/pkg/lib/common/references.go
+++ b/pkg/lib/common/references.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common
 
 // GeneralReference struct contains data for the name and path of a

--- a/pkg/lib/common/references_test.go
+++ b/pkg/lib/common/references_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common
 
 import "testing"

--- a/pkg/lib/common/standard.go
+++ b/pkg/lib/common/standard.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common
 
 //go:generate mockery -name Standard -testonly

--- a/pkg/lib/common/verifications.go
+++ b/pkg/lib/common/verifications.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common
 
 // Verification struct holds data for a specific component and verification

--- a/pkg/lib/common/verifications_test.go
+++ b/pkg/lib/common/verifications_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common_test
 
 import (

--- a/pkg/lib/common/workspace.go
+++ b/pkg/lib/common/workspace.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package common
 
 //go:generate mockery -name Workspace -testonly

--- a/pkg/lib/components.go
+++ b/pkg/lib/components.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package lib
 
 import (

--- a/pkg/lib/components/component.go
+++ b/pkg/lib/components/component.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package components
 
 import (

--- a/pkg/lib/components/component_test.go
+++ b/pkg/lib/components/component_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package components
 
 import "testing"

--- a/pkg/lib/components/parse.go
+++ b/pkg/lib/components/parse.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package components
 
 import (

--- a/pkg/lib/components/parse_test.go
+++ b/pkg/lib/components/parse_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package components_test
 
 import (

--- a/pkg/lib/components/versions/2_0_0/component.go
+++ b/pkg/lib/components/versions/2_0_0/component.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package component
 
 import (

--- a/pkg/lib/components/versions/2_0_0/component_test.go
+++ b/pkg/lib/components/versions/2_0_0/component_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package component
 
 import (

--- a/pkg/lib/components/versions/3_0_0/component.go
+++ b/pkg/lib/components/versions/3_0_0/component.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package component
 
 import (

--- a/pkg/lib/components/versions/3_0_0/component_test.go
+++ b/pkg/lib/components/versions/3_0_0/component_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package component
 
 import (

--- a/pkg/lib/components/versions/3_1_0/component.go
+++ b/pkg/lib/components/versions/3_1_0/component.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package component
 
 import (

--- a/pkg/lib/components/versions/3_1_0/component_test.go
+++ b/pkg/lib/components/versions/3_1_0/component_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package component
 
 import (

--- a/pkg/lib/components_test.go
+++ b/pkg/lib/components_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package lib
 
 import (

--- a/pkg/lib/opencontrol/opencontrol.go
+++ b/pkg/lib/opencontrol/opencontrol.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package opencontrol
 
 import (

--- a/pkg/lib/opencontrol/opencontrol_suite_test.go
+++ b/pkg/lib/opencontrol/opencontrol_suite_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package opencontrol_test
 
 import (

--- a/pkg/lib/opencontrol/opencontrol_test.go
+++ b/pkg/lib/opencontrol/opencontrol_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package opencontrol
 
 import (

--- a/pkg/lib/opencontrol/parse.go
+++ b/pkg/lib/opencontrol/parse.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package opencontrol
 
 import (

--- a/pkg/lib/opencontrol/parse_test.go
+++ b/pkg/lib/opencontrol/parse_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package opencontrol_test
 
 import (

--- a/pkg/lib/opencontrol/versions/1.0.0/1.0.0_suite_test.go
+++ b/pkg/lib/opencontrol/versions/1.0.0/1.0.0_suite_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package schema_test
 
 import (

--- a/pkg/lib/opencontrol/versions/1.0.0/opencontrol.go
+++ b/pkg/lib/opencontrol/versions/1.0.0/opencontrol.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package schema
 
 import (

--- a/pkg/lib/opencontrol/versions/1.0.0/opencontrol_test.go
+++ b/pkg/lib/opencontrol/versions/1.0.0/opencontrol_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package schema
 
 import (

--- a/pkg/lib/result/justifications.go
+++ b/pkg/lib/result/justifications.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package result
 
 import (

--- a/pkg/lib/result/justifications_test.go
+++ b/pkg/lib/result/justifications_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package result
 
 import "testing"

--- a/pkg/lib/standards.go
+++ b/pkg/lib/standards.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package lib
 
 import (

--- a/pkg/lib/standards/standard.go
+++ b/pkg/lib/standards/standard.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package standards
 
 import (

--- a/pkg/lib/standards/standard_test.go
+++ b/pkg/lib/standards/standard_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package standards
 
 import (

--- a/pkg/lib/standards/versions/1_0_0/standard.go
+++ b/pkg/lib/standards/versions/1_0_0/standard.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package standard
 
 import (

--- a/pkg/lib/standards/versions/1_0_0/standard_test.go
+++ b/pkg/lib/standards/versions/1_0_0/standard_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package standard
 
 import "testing"

--- a/pkg/lib/standards_test.go
+++ b/pkg/lib/standards_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package lib
 
 import (

--- a/pkg/lib/workspace.go
+++ b/pkg/lib/workspace.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package lib
 
 import (

--- a/pkg/lib/workspace_test.go
+++ b/pkg/lib/workspace_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package lib
 
 import (

--- a/pkg/tests/test_masonry.go
+++ b/pkg/tests/test_masonry.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package masonry_test
 
 import (

--- a/tools/certifications/certifications.go
+++ b/tools/certifications/certifications.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package certifications
 
 import (

--- a/tools/constants/constants.go
+++ b/tools/constants/constants.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package constants
 
 const (

--- a/tools/fs/fs.go
+++ b/tools/fs/fs.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package fs
 
 import (

--- a/tools/mapset/map.go
+++ b/tools/mapset/map.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package mapset
 
 import (

--- a/tools/mapset/map_test.go
+++ b/tools/mapset/map_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package mapset
 
 import (

--- a/tools/mapset/mapset_suite_test.go
+++ b/tools/mapset/mapset_suite_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package mapset_test
 
 import (

--- a/tools/vcs/manager.go
+++ b/tools/vcs/manager.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package vcs
 
 import (

--- a/tools/vcs/manager_test.go
+++ b/tools/vcs/manager_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package vcs
 
 import (

--- a/tools/vcs/vcs_suite_test.go
+++ b/tools/vcs/vcs_suite_test.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package vcs_test
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,7 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
 package version
 
 // Version is the version of the build.


### PR DESCRIPTION
This just adds the Copyright/License reference to the .go files.