### PR TITLE
Make sure to account if compliance-masonry path is in a subdirectory

### DIFF
--- a/cmd/compliance-masonry/compliance-masonry.go
+++ b/cmd/compliance-masonry/compliance-masonry.go
@@ -23,7 +23,8 @@ func main() {
 		binary = "masonry"
 	}
 
-	prog, err := filepath.Abs(filepath.Join(binary))
+	basepath := filepath.Dir(os.Args[0])
+	prog, err := filepath.Abs(filepath.Join(basepath, binary))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Fixes the issue when running the `compliance-masonry` command like so:

- `./somedir/compliance-masonry`
- `../../../somedir/compliance-masonry`