### PR TITLE
More goreleaser fixes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,4 +48,6 @@ brew:
   commit_author:
     name: OpenControl
     email: dev@open-control.org
+  description: Compliance Masonry is a command-line interface (CLI) that allows users to construct certification documentation using the OpenControl Schema.
   homepage: https://github.com/opencontrol/compliance-masonry
+  install: bin.install "compliance-masonry", "masonry"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 SELINUXOPT ?= $(shell selinuxenabled 2>/dev/null && echo -Z)
 
 BUILD_DIR ?= ./build
-BUILD_INFO := $(shell date --iso-8601=s --utc)
+BUILD_INFO := $(shell date -u +"%Y-%m-%dT%T%z")
 BUILD_PLATFORMS = "windows/amd64" "windows/386" "darwin/amd64" "darwin/386" "linux/386" "linux/amd64" "linux/arm" "linux/arm64"
 
 VERSION := $(shell git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags | cut -d"v" -f2)


### PR DESCRIPTION
- Fix homebrew installs
- Search `env $PATH` in cause masonry executable cannot be found