### PR TITLE
Fix GIT version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BUILD_DIR ?= _output
 BUILD_INFO := $(shell date -u +"%Y-%m-%dT%T%z")
 BUILD_PLATFORMS = "windows/amd64" "windows/386" "darwin/amd64" "darwin/386" "linux/386" "linux/amd64" "linux/arm" "linux/arm64"
 
-VERSION := $(shell git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags | cut -d"v" -f2)
+VERSION := $(shell git describe --abbrev=0 --tags | cut -d"v" -f2)
 SHORTCOMMIT := $(shell git rev-parse --short HEAD)
 
 # If GOPATH not specified, use one in the local directory


### PR DESCRIPTION
Now that `git tag` is done properly, we should get the version with `git describe`