### PR TITLE
Fix file names and permissions

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,13 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
+package constants
+
+const (
+	// FileReadWrite handle Read/Write File Permissions
+	FileReadWrite = 0600
+
+	// FileReadWriteExec handle Read/Write/Write Execute Permissions
+	FileReadWriteExec = 0700
+)

--- a/internal/utils/masonryutil.go
+++ b/internal/utils/masonryutil.go
@@ -1,0 +1,37 @@
+/*
+ Copyright (C) 2018 OpenControl Contributors. See LICENSE.md for license.
+*/
+
+package masonryutil
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// replaceParentheses removes parenthesis in strings
+func replaceParentheses(text string) string {
+	return strings.Replace(strings.Replace(text, "(", "", -1), ")", "", -1)
+}
+
+// replaceSpace changes whitepspace to underscore in strings
+func replaceSpaceUnderscore(text string) string {
+	return strings.Replace(text, " ", "_", -1)
+}
+
+// FileNameHandler creates a standardized filename
+func FileNameHandler(fileName string) string {
+	normalizedFileName := replaceParentheses(fileName)
+	normalizedFileName = replaceSpaceUnderscore(normalizedFileName)
+
+	return normalizedFileName
+}
+
+// FileWriter handles all file writing for Compliance Masonry
+func FileWriter(filePath string, fileText []byte, filePerms os.FileMode) {
+	err := ioutil.WriteFile(filePath, fileText, filePerms)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/cli/docs/gitbook/gitbook.go
+++ b/pkg/cli/docs/gitbook/gitbook.go
@@ -7,7 +7,6 @@ package gitbook
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/opencontrol/compliance-masonry/pkg/lib"
 	"github.com/opencontrol/compliance-masonry/pkg/lib/common"
@@ -49,10 +48,6 @@ type ControlGitbook struct {
 
 func exportLink(text string, location string) string {
 	return fmt.Sprintf("* [%s](%s)\n", text, location)
-}
-
-func replaceParentheses(text string) string {
-	return strings.Replace(strings.Replace(text, "(", "", -1), ")", "", -1)
 }
 
 // BuildGitbook entry point for creating gitbook

--- a/pkg/cli/docs/gitbook/gitbookCertification.go
+++ b/pkg/cli/docs/gitbook/gitbookCertification.go
@@ -6,9 +6,11 @@ package gitbook
 
 import (
 	"fmt"
-	"io/ioutil"
+
 	"path/filepath"
 
+	"github.com/opencontrol/compliance-masonry/internal/constants"
+	"github.com/opencontrol/compliance-masonry/internal/utils"
 	"github.com/opencontrol/compliance-masonry/pkg/lib/common"
 )
 
@@ -92,7 +94,7 @@ func (openControl *OpenControlGitBook) getControlOrigin(text string, controlOrig
 }
 
 func (openControl *OpenControlGitBook) exportControl(control *ControlGitbook) (string, string) {
-	key := replaceParentheses(fmt.Sprintf("%s-%s", control.standardKey, control.controlKey))
+	key := masonryutil.FileNameHandler(fmt.Sprintf("%s-%s", control.standardKey, control.controlKey))
 	text := fmt.Sprintf("# %s\n## %s\n", key, control.GetName())
 	if len(control.GetDescription()) > 0 {
 		text += "#### Description\n"
@@ -136,7 +138,7 @@ func (openControl *OpenControlGitBook) exportStandards() {
 		for _, controlKey := range controlKeys {
 			control := standard.GetControl(controlKey)
 			controlPath, controlText := openControl.exportControl(&ControlGitbook{control, standardsExportPath, standardKey, controlKey})
-			ioutil.WriteFile(controlPath, []byte(controlText), 0700)
+			masonryutil.FileWriter(controlPath, []byte(controlText), constants.FileReadWrite)
 		}
 	}
 }

--- a/pkg/cli/docs/gitbook/gitbookComponents.go
+++ b/pkg/cli/docs/gitbook/gitbookComponents.go
@@ -6,9 +6,11 @@ package gitbook
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"sort"
+
+	"github.com/opencontrol/compliance-masonry/internal/constants"
+	"github.com/opencontrol/compliance-masonry/internal/utils"
 )
 
 func (component *ComponentGitbook) exportComponent() (string, string) {
@@ -43,6 +45,6 @@ func (openControl *OpenControlGitBook) exportComponents() {
 	for _, component := range openControl.GetAllComponents() {
 		componentsGitBook := ComponentGitbook{component, componentsExportPath}
 		componentPath, componentText := componentsGitBook.exportComponent()
-		ioutil.WriteFile(componentPath, []byte(componentText), 0700)
+		masonryutil.FileWriter(componentPath, []byte(componentText), constants.FileReadWrite)
 	}
 }

--- a/pkg/cli/docs/gitbook/gitbookSummaries.go
+++ b/pkg/cli/docs/gitbook/gitbookSummaries.go
@@ -7,9 +7,11 @@ package gitbook
 import (
 	"fmt"
 	"github.com/opencontrol/compliance-masonry/pkg/lib/common"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
+
+	"github.com/opencontrol/compliance-masonry/internal/constants"
+	"github.com/opencontrol/compliance-masonry/internal/utils"
 )
 
 // createSubHeading will create a subheading with the passed in string.
@@ -80,7 +82,7 @@ func (*OpenControlGitBook) buildStandardsSummary(standardKey, controlKey string,
 	oldFamilyFileName fileName, familySummaryMap map[string]string) (string, fileName, map[string]string) {
 	summary := ""
 	// format the filename
-	controlLink := replaceParentheses(createFileName(standardKey, controlKey).withExt(".md"))
+	controlLink := masonryutil.FileNameHandler(createFileName(standardKey, controlKey).withExt(".md"))
 
 	// get the control.
 	control := standard.GetControl(controlKey)
@@ -112,7 +114,7 @@ func (*OpenControlGitBook) buildStandardsSummary(standardKey, controlKey string,
 
 func (openControl *OpenControlGitBook) exportFamilyReadMap(familySummaryMap *map[string]string) {
 	for family, familySummary := range *(familySummaryMap) {
-		ioutil.WriteFile(filepath.Join(openControl.exportPath, "standards", family+".md"), []byte(familySummary), 0700)
+		masonryutil.FileWriter(filepath.Join(openControl.exportPath, "standards", family+".md"), []byte(familySummary), constants.FileReadWrite)
 	}
 }
 

--- a/pkg/cli/docs/gitbook/gitbook_test.go
+++ b/pkg/cli/docs/gitbook/gitbook_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/opencontrol/compliance-masonry/internal/utils"
 )
 
 type exportLinkTest struct {
@@ -56,7 +58,7 @@ var replaceParenthesesTests = []replaceParenthesesTest{
 
 func TestReplaceParentheses(t *testing.T) {
 	for _, example := range replaceParenthesesTests {
-		actual := replaceParentheses(example.text)
+		actual := masonryutil.FileNameHandler(example.text)
 		if actual != example.expected {
 			t.Errorf("Expected: `%s`, Actual: `%s`", example.expected, actual)
 		}

--- a/tools/fs/fs.go
+++ b/tools/fs/fs.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	metaleapfs "github.com/metaleap/go-util/fs"
+	"github.com/opencontrol/compliance-masonry/internal/constants"
 )
 
 //go:generate mockery -name Util
@@ -69,14 +70,14 @@ func (fs OSUtil) AppendOrCreate(filePath string, text string) error {
 	if _, err = os.Stat(filePath); err == nil {
 		err = AppendToFile(filePath, text)
 	} else {
-		err = ioutil.WriteFile(filePath, []byte(text), 0700)
+		err = ioutil.WriteFile(filePath, []byte(text), constants.FileReadWrite)
 	}
 	return err
 }
 
 // AppendToFile adds text to a file
 func AppendToFile(filePath string, text string) error {
-	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0700)
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, constants.FileReadWrite)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Add file permissions constants
- Files shouldn't be executable
- Files shouldn't use spaces in file names for multi-OS support