### PR TITLE
uplift goreleaser config beyond noted deprecations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+---
 builds:
   - binary: masonry
     main: ./cmd/masonry/masonry.go
@@ -27,31 +28,31 @@ builds:
       - arm
       - 386
 
-archive:
-  files:
-    - LICENSE.md
-    - README.md
-  format_overrides:
-    - goos: windows
-      format: zip
+archives:
+  - files:
+      - LICENSE.md
+      - README.md
+    format_overrides:
+      - goos: windows
+        format: zip
 
-nfpm:
-  vendor: OpenControl
-  homepage: https://github.com/opencontrol/compliance-masonry
-  license: CC0 1.0
-  maintainer: OpenControl Developers <dev@open-control.org>
-  formats:
-    - deb
-    - rpm
+nfpms:
+  - vendor: OpenControl
+    homepage: https://github.com/opencontrol/compliance-masonry
+    license: CC0 1.0
+    maintainer: OpenControl Developers <dev@open-control.org>
+    formats:
+      - deb
+      - rpm
 
-brew:
-  name: compliance-masonry
-  github:
-    owner: opencontrol
-    name: homebrew-compliance-masonry
-  commit_author:
-    name: OpenControl
-    email: dev@open-control.org
-  description: Compliance Masonry is a command-line interface (CLI) that allows users to construct certification documentation using the OpenControl Schema.
-  homepage: https://github.com/opencontrol/compliance-masonry
-  install: bin.install "compliance-masonry", "masonry"
+brews:
+  - name: compliance-masonry
+    tap:
+      owner: opencontrol
+      name: homebrew-compliance-masonry
+    commit_author:
+      name: OpenControl
+      email: dev@open-control.org
+    description: Compliance Masonry is a command-line interface (CLI) that allows users to construct certification documentation using the OpenControl Schema.
+    homepage: https://github.com/opencontrol/compliance-masonry
+    install: bin.install "compliance-masonry", "masonry"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ You can install compliance-masonry on MacOS using the following methods:
 1. Double-click on the MSI package.
 1. Simply drag the compliance-masonry icon to your Applications folder.
 
+#### Homebrew Installation
+```sh
+brew install opencontrol/compliance-masonry/compliance-masonry
+```
+
 #### Installing from Archive
 1. Go to [the Github Release](https://github.com/opencontrol/compliance-masonry/releases/latest).
 1. Download the archive package that corresponds to your machine and operating system.

--- a/pkg/cli/validate/validate.go
+++ b/pkg/cli/validate/validate.go
@@ -1,0 +1,20 @@
+package validate
+
+import (
+	"io"
+
+	"github.com/opencontrol/compliance-masonry/validate"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdValidate validates the current masonry
+func NewCmdValidate(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate input file",
+		Run: func(cmd *cobra.Command, args []string) {
+			validate.Validate()
+		},
+	}
+	return cmd
+}

--- a/pkg/cli/validate/validate.go
+++ b/pkg/cli/validate/validate.go
@@ -11,7 +11,7 @@ import (
 func NewCmdValidate(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate",
-		Short: "Validate input file",
+		Short: "Validates the current opencontrol masonry repository. Use get command to create opencontrol masonry repository.",
 		Run: func(cmd *cobra.Command, args []string) {
 			validate.Validate()
 		},

--- a/pkg/cmd/masonry/cmd.go
+++ b/pkg/cmd/masonry/cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opencontrol/compliance-masonry/pkg/cli/export"
 	"github.com/opencontrol/compliance-masonry/pkg/cli/get"
 	"github.com/opencontrol/compliance-masonry/pkg/cli/info"
+	"github.com/opencontrol/compliance-masonry/pkg/cli/validate"
 	cliversion "github.com/opencontrol/compliance-masonry/pkg/cli/version"
 	"github.com/opencontrol/compliance-masonry/version"
 	"github.com/spf13/cobra"
@@ -63,6 +64,7 @@ the OpenControl Schema`,
 	cmds.AddCommand(export.NewCmdExport(out))
 	cmds.AddCommand(get.NewCmdGet(out))
 	cmds.AddCommand(cliversion.NewCmdVersion(out))
+	cmds.AddCommand(validate.NewCmdValidate(out))
 
 	disableFlagsInUseLine(cmds)
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -47,7 +47,7 @@ func validateComponent(workspace common.Workspace, component common.Component) [
 
 		_, found := uniq[standardKey][satisfy.GetControlKey()]
 		if found {
-			problems = append(problems, fmt.Sprintf("Found duplicate item: %s", satisfy.GetControlKey()))
+			problems = append(problems, fmt.Sprintf("Component %s: Duplicate items found: %s", component.GetKey(), satisfy.GetControlKey()))
 		}
 		uniq[standardKey][satisfy.GetControlKey()] = satisfy
 
@@ -58,13 +58,13 @@ func validateComponent(workspace common.Workspace, component common.Component) [
 			problems = append(problems, fmt.Sprintf("Found non-standard implementation_status: %s.", satisfy.GetImplementationStatus()))
 			break
 		}
-		problems = append(problems, validateNarratives(satisfy)...)
+		problems = append(problems, validateNarratives(component, satisfy)...)
 
 	}
 	return problems
 }
 
-func validateNarratives(satisfy common.Satisfies) []string {
+func validateNarratives(component common.Component, satisfy common.Satisfies) []string {
 	problems := make([]string, 0)
 
 	requireKey := len(satisfy.GetNarratives()) > 1
@@ -72,18 +72,18 @@ func validateNarratives(satisfy common.Satisfies) []string {
 	for _, narrative := range satisfy.GetNarratives() {
 		key := narrative.GetKey()
 		if requireKey && key == "" {
-			problems = append(problems, fmt.Sprintf("Satisfy '%s': Narrative key is required when multiple narratives are present.", satisfy.GetControlKey()))
+			problems = append(problems, fmt.Sprintf("Component %s: Satisfy '%s': Narrative key is required when multiple narratives are present.", component.GetKey(), satisfy.GetControlKey()))
 		}
 
 		if len(key) > 6 {
-			problems = append(problems, fmt.Sprintf("Satisfy '%s': Long narrative key probably malformed: '%s'", satisfy.GetControlKey(), key))
+			problems = append(problems, fmt.Sprintf("Component %s: Satisfy '%s': Long narrative key probably malformed: '%s'", component.GetKey(), satisfy.GetControlKey(), key))
 
 		}
 
 		if key != "" {
 			_, found := uniqNarratives[key]
 			if found {
-				problems = append(problems, fmt.Sprintf("Satisfy '%s': Duplicate narratives sequence: %s", satisfy.GetControlKey(), key))
+				problems = append(problems, fmt.Sprintf("Component %s:, Satisfy '%s': Duplicate narratives sequence found: %s", component.GetKey(), satisfy.GetControlKey(), key))
 
 			}
 		}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -1,0 +1,86 @@
+package validate
+
+import (
+	"fmt"
+	"github.com/opencontrol/compliance-masonry/pkg/lib"
+	"github.com/opencontrol/compliance-masonry/pkg/lib/common"
+	"os"
+)
+
+// Validate validates opencontrol masonry repository that has been previously obtained by masonry get
+func Validate() {
+	problems := make([]string, 0)
+	workspace, errors := lib.LoadData("opencontrols/", "opencontrols/certifications/fedramp-high.yaml")
+	if errors != nil {
+		fmt.Println(errors)
+		os.Exit(1)
+	}
+	for _, component := range workspace.GetAllComponents() {
+		problems = append(problems, validateComponent(workspace, component)...)
+	}
+	for _, problem := range problems {
+		fmt.Println(problem)
+	}
+	os.Exit(len(problems))
+}
+
+func validateComponent(workspace common.Workspace, component common.Component) []string {
+	problems := make([]string, 0)
+	uniq := make(map[string]map[string]common.Satisfies)
+
+	for _, satisfy := range component.GetAllSatisfies() {
+		standardKey := satisfy.GetStandardKey()
+		_, ok := uniq[standardKey]
+		if !ok {
+			_, found := workspace.GetStandard(standardKey)
+			if !found {
+				problems = append(problems, fmt.Sprintf("Component %s references standard %s, however that cannot be found in the workspace.", component.GetName(), standardKey))
+			}
+			uniq[standardKey] = make(map[string]common.Satisfies)
+		}
+		standard, _ := workspace.GetStandard(standardKey)
+
+		standardControl := standard.GetControl(satisfy.GetControlKey())
+		if standardControl == nil {
+			problems = append(problems, fmt.Sprintf("Could not find reference %s in the standard %s", satisfy.GetControlKey(), standardKey))
+		}
+
+		_, found := uniq[standardKey][satisfy.GetControlKey()]
+		if found {
+			problems = append(problems, fmt.Sprintf("Found duplicate item: %s", satisfy.GetControlKey()))
+		}
+		uniq[standardKey][satisfy.GetControlKey()] = satisfy
+
+		switch satisfy.GetImplementationStatus() {
+		case "complete", "partial", "not applicable", "planned", "unsatisfied", "unknown", "none":
+			break
+		default:
+			problems = append(problems, fmt.Sprintf("Found non-standard implementation_status: %s.", satisfy.GetImplementationStatus()))
+			break
+		}
+
+		requireKey := len(satisfy.GetNarratives()) > 1
+		uniqNarratives := make(map[string]bool)
+		for _, narrative := range satisfy.GetNarratives() {
+			key := narrative.GetKey()
+			if requireKey && key == "" {
+				problems = append(problems, fmt.Sprintf("Satisfy '%s': Narrative key is required when multiple narratives are present.", satisfy.GetControlKey()))
+			}
+
+			if len(key) > 6 {
+				problems = append(problems, fmt.Sprintf("Satisfy '%s': Long narrative key probably malformed: '%s'", satisfy.GetControlKey(), key))
+
+			}
+
+			if key != "" {
+				_, found := uniqNarratives[key]
+				if found {
+					problems = append(problems, fmt.Sprintf("Satisfy '%s': Duplicate narratives sequence: %s", satisfy.GetControlKey(), key))
+
+				}
+			}
+			uniqNarratives[key] = true
+		}
+	}
+	return problems
+}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -58,29 +58,36 @@ func validateComponent(workspace common.Workspace, component common.Component) [
 			problems = append(problems, fmt.Sprintf("Found non-standard implementation_status: %s.", satisfy.GetImplementationStatus()))
 			break
 		}
+		problems = append(problems, validateNarratives(satisfy)...)
 
-		requireKey := len(satisfy.GetNarratives()) > 1
-		uniqNarratives := make(map[string]bool)
-		for _, narrative := range satisfy.GetNarratives() {
-			key := narrative.GetKey()
-			if requireKey && key == "" {
-				problems = append(problems, fmt.Sprintf("Satisfy '%s': Narrative key is required when multiple narratives are present.", satisfy.GetControlKey()))
-			}
+	}
+	return problems
+}
 
-			if len(key) > 6 {
-				problems = append(problems, fmt.Sprintf("Satisfy '%s': Long narrative key probably malformed: '%s'", satisfy.GetControlKey(), key))
+func validateNarratives(satisfy common.Satisfies) []string {
+	problems := make([]string, 0)
 
-			}
-
-			if key != "" {
-				_, found := uniqNarratives[key]
-				if found {
-					problems = append(problems, fmt.Sprintf("Satisfy '%s': Duplicate narratives sequence: %s", satisfy.GetControlKey(), key))
-
-				}
-			}
-			uniqNarratives[key] = true
+	requireKey := len(satisfy.GetNarratives()) > 1
+	uniqNarratives := make(map[string]bool)
+	for _, narrative := range satisfy.GetNarratives() {
+		key := narrative.GetKey()
+		if requireKey && key == "" {
+			problems = append(problems, fmt.Sprintf("Satisfy '%s': Narrative key is required when multiple narratives are present.", satisfy.GetControlKey()))
 		}
+
+		if len(key) > 6 {
+			problems = append(problems, fmt.Sprintf("Satisfy '%s': Long narrative key probably malformed: '%s'", satisfy.GetControlKey(), key))
+
+		}
+
+		if key != "" {
+			_, found := uniqNarratives[key]
+			if found {
+				problems = append(problems, fmt.Sprintf("Satisfy '%s': Duplicate narratives sequence: %s", satisfy.GetControlKey(), key))
+
+			}
+		}
+		uniqNarratives[key] = true
 	}
 	return problems
 }


### PR DESCRIPTION
In order to use `.goreleaser.yml` for building and releasing `masonry` with up to date versions of goreleaser, the [few deprecations as noted here on goreleaser's site should be updated](https://goreleaser.com/deprecations/) so the config is compatible with newer versions of goreleaser.

for transparency: using this version of goreleaser...

```sh
goreleaser -v

goreleaser version 0.142.0
commit: e014ad0ae88480406206c7758f3607168b45ced9
built at: 2020-08-22T22:00:14Z
built by: goreleaser
```

...threw these warnings:

```
$ goreleaser check
   • loading config file       file=.goreleaser.yml
   ⨯ command failed            error=yaml: unmarshal errors:
  line 31: field archive not found in type config.Project
  line 39: field nfpm not found in type config.Project
  line 48: field brew not found in type config.Project
```

all changes made using the 'deprecation notices' as a guide https://goreleaser.com/deprecations/

thanks for the time and consideration 👍 