### PR TITLE
uplift goreleaser config beyond noted deprecations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
+---
 builds:
-  - binary: masonry
+  - id: masonry
+    binary: masonry
     main: ./cmd/masonry/masonry.go
     ldflags: -s -w -X github.com/opencontrol/compliance-masonry/version.Version={{.Version}} -X github.com/opencontrol/compliance-masonry/version.Commit={{.Commit}} -X github.com/opencontrol/compliance-masonry/version.Date={{.Date}}
     env:
@@ -12,7 +14,8 @@ builds:
       - amd64
       - arm64
 
-  - binary: compliance-masonry
+  - id: compliance-masonry
+    binary: compliance-masonry
     main: ./cmd/compliance-masonry/compliance-masonry.go
     ldflags: -s -w -X github.com/opencontrol/compliance-masonry/version.Version={{.Version}} -X github.com/opencontrol/compliance-masonry/version.Commit={{.Commit}} -X github.com/opencontrol/compliance-masonry/version.Date={{.Date}}
     env:
@@ -27,31 +30,31 @@ builds:
       - arm
       - 386
 
-archive:
-  files:
-    - LICENSE.md
-    - README.md
-  format_overrides:
-    - goos: windows
-      format: zip
+archives:
+  - files:
+      - LICENSE.md
+      - README.md
+    format_overrides:
+      - goos: windows
+        format: zip
 
-nfpm:
-  vendor: OpenControl
-  homepage: https://github.com/opencontrol/compliance-masonry
-  license: CC0 1.0
-  maintainer: OpenControl Developers <dev@open-control.org>
-  formats:
-    - deb
-    - rpm
+nfpms:
+  - vendor: OpenControl
+    homepage: https://github.com/opencontrol/compliance-masonry
+    license: CC0 1.0
+    maintainer: OpenControl Developers <dev@open-control.org>
+    formats:
+      - deb
+      - rpm
 
-brew:
-  name: compliance-masonry
-  github:
-    owner: opencontrol
-    name: homebrew-compliance-masonry
-  commit_author:
-    name: OpenControl
-    email: dev@open-control.org
-  description: Compliance Masonry is a command-line interface (CLI) that allows users to construct certification documentation using the OpenControl Schema.
-  homepage: https://github.com/opencontrol/compliance-masonry
-  install: bin.install "compliance-masonry", "masonry"
+brews:
+  - name: compliance-masonry
+    tap:
+      owner: opencontrol
+      name: homebrew-compliance-masonry
+    commit_author:
+      name: OpenControl
+      email: dev@open-control.org
+    description: Compliance Masonry is a command-line interface (CLI) that allows users to construct certification documentation using the OpenControl Schema.
+    homepage: https://github.com/opencontrol/compliance-masonry
+    install: bin.install "compliance-masonry", "masonry"


### PR DESCRIPTION
replacement PR of https://github.com/opencontrol/compliance-masonry/pull/353

In order to use `.goreleaser.yml` for building and releasing `masonry` with up to date versions of goreleaser, the [few deprecations as noted here on goreleaser's site should be updated](https://goreleaser.com/deprecations/) so the config is compatible with newer versions of goreleaser.

for transparency: using this version of goreleaser...

```sh
goreleaser -v

goreleaser version 0.142.0
commit: e014ad0ae88480406206c7758f3607168b45ced9
built at: 2020-08-22T22:00:14Z
built by: goreleaser
```

...threw these errors:

```sh
$ goreleaser check
   • loading config file       file=.goreleaser.yml
   ⨯ command failed            error=yaml: unmarshal errors:
  line 31: field archive not found in type config.Project
  line 39: field nfpm not found in type config.Project
  line 48: field brew not found in type config.Project
```

which are now fixed up 👍 

~~However, this doesn't 100% guarantee the config is semantically correct, just syntactically correct. Specifically what has me a little concerned is the `bin.install` description for homebrew, I'm not completely confident what this will do. I might put together a test repo myself to try it out~~

generated `compliance-masonry.rb` :

```rb
# This file was generated by GoReleaser. DO NOT EDIT.
class ComplianceMasonry < Formula
  desc "Compliance Masonry is a command-line interface (CLI) that allows users to construct certification documentation using the OpenControl Schema."
  homepage "https://github.com/opencontrol/compliance-masonry"
  version "1.1.6"
  bottle :unneeded

  if OS.mac?
    url "https://github.com/aegershman/compliance-masonry/releases/download/v1.1.6/compliance-masonry_1.1.6_darwin_amd64.tar.gz"
    sha256 "91efee0f4939b0b1e44e3c1b018acb666f88743bea1a41db29a0665f6f288f2c"
  elsif OS.linux?
    if Hardware::CPU.intel?
      url "https://github.com/aegershman/compliance-masonry/releases/download/v1.1.6/compliance-masonry_1.1.6_linux_amd64.tar.gz"
      sha256 "feaba5e9afcfffd1a9836d270d91bb26ea971789b87611f761230794deeaa05c"
    end
    if Hardware::CPU.arm?
      if Hardware::CPU.is_64_bit?
        url "https://github.com/aegershman/compliance-masonry/releases/download/v1.1.6/compliance-masonry_1.1.6_linux_arm64.tar.gz"
        sha256 "7f2768a81412133584aa49308f97010088240bf30fbcb0a4e1ef55b984533388"
      else
        url "https://github.com/aegershman/compliance-masonry/releases/download/v1.1.6/compliance-masonry_1.1.6_linux_armv6.tar.gz"
        sha256 "b6cf0dfbe408d7cba9f5bd6656169f081fbf57198d8a7b8fb52cd8350cb05fca"
      end
    end
  end

  def install
    bin.install "compliance-masonry", "masonry"
  end
end
```

As an aside, I'm wondering if the build/{`dmg`,`msi`} builds are especially necessary anymore? And if whether [`goreleaser` can be used to output any created docker image?](https://goreleaser.com/customization/docker/) Or to handle generating the github release of the associated version? or could be used to replace the kind of gnarly Makefile? those are just side-thoughts, not a huge deal / directly related to this PR.

Thanks for the time and consideration 