### PR TITLE
Dependabot for gomod updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
part of https://github.com/opencontrol/compliance-masonry/issues/358

contingent on:
- https://github.com/opencontrol/compliance-masonry/pull/355
- https://github.com/opencontrol/compliance-masonry/issues/350

see also:
- https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/
- similar issue noted in opencontainers https://github.com/opencontainers/runc/issues/2536

Introduces leveraging dependabot for analyzing gomod updates. However, this might be problematic with `vendor/` due to dependabot not currently supporting the ability to additionally perform `go mod vendor` as per this issue: https://github.com/dependabot/dependabot-core/issues/670 -- this appears to be being handled in other projects (https://github.com/vmware-tanzu/octant/blob/master/.github/workflows/dependabot-gomod.yaml) by having a github action workflow (see also: https://github.com/opencontrol/compliance-masonry/issues/357) which performs go mod vendor on the PR which dependabot opens, which might not be too awful. If nothing else, this would enable being notified of available updates, and gets the ball rolling to start analyzing changes

We can also set this lower to something like "max open PRs, 5" so dependabot doesn't explode (the goal being that it never would get that bad), let me know what you all think

Thanks for the time and consideration 👍 