### PR TITLE
Enable GH Actions for linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,6 @@ jobs:
       - run:
           name: Run tests
           command: ./.circleci/coverage.sh
-      - run:
-          name: Send results to Codecov
-          shell: /bin/bash
-          command: bash <(curl -s https://codecov.io/bash)
       - deploy:
           name: goreleaser
           command: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,24 +1,19 @@
-name: Go
+---
+name: build
 on: [push]
 jobs:
-  run:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-    env:
-      OS: ${{ matrix.os }}
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
+        uses: actions/checkout@v2
 
       - name: Build compliance-masonry
         run: go build cmd/compliance-masonry/compliance-masonry.go
@@ -28,7 +23,7 @@ jobs:
 
       - name: Run tests
         run: |
-          go test $(go list ./...) -covermode=count -coverprofile=coverage.txt
+          go test -covermode=count -coverprofile=coverage.txt ./...
           go tool cover -func coverage.txt
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Go
+on: [push]
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    env:
+      OS: ${{ matrix.os }}
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: Build compliance-masonry
+        run: go build cmd/compliance-masonry/compliance-masonry.go
+
+      - name: Build masonry
+        run: go build cmd/masonry/masonry.go
+
+      - name: Run tests
+        run: |
+          go test $(go list ./...) -covermode=count -coverprofile=coverage.txt
+          go tool cover -func coverage.txt
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          file: ./coverage.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Build compliance-masonry
-        run: go build cmd/compliance-masonry/compliance-masonry.go
-
-      - name: Build masonry
-        run: go build cmd/masonry/masonry.go
+      - name: Build compliance-masonry and masonry
+        run: go build -o _output/ ./cmd/...
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This allows testing to happen using GH actions. MacOS and Windows builds are failing their tests on different items, so they will have to be added later.