### PR TITLE
Do not fail hard when someone mistypes standard key

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -35,6 +35,7 @@ func validateComponent(workspace common.Workspace, component common.Component) [
 			_, found := workspace.GetStandard(standardKey)
 			if !found {
 				problems = append(problems, fmt.Sprintf("Component %s references standard %s, however that cannot be found in the workspace.", component.GetName(), standardKey))
+				continue
 			}
 			uniq[standardKey] = make(map[string]common.Satisfies)
 		}


### PR DESCRIPTION
Fail soft instead. Example of failure message:

    Component RHEL CoreOS 4 references standard NIST-800-531, however that cannot be found in the workspace

Addressing:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x13f28ee]

goroutine 1 [running]:
github.com/opencontrol/compliance-masonry/validate.validateComponent(0x154d500, 0xc000097c80, 0x154d5c0, 0xc00165c000, 0x0, 0x0, 0x0)
        github.com/opencontrol/compliance-masonry/validate/validate.go:43 +0x22e
github.com/opencontrol/compliance-masonry/validate.Validate()
        github.com/opencontrol/compliance-masonry/validate/validate.go:19 +0x12a
github.com/opencontrol/compliance-masonry/pkg/cli/validate.NewCmdValidate.func1(0xc0001a4b00, 0x17e8c98, 0x0, 0x0)
        github.com/opencontrol/compliance-masonry/pkg/cli/validate/validate.go:16 +0x25
github.com/opencontrol/compliance-masonry/vendor/github.com/spf13/cobra.(*Command).execute(0xc0001a4b00, 0x17e8c98, 0x0, 0x0, 0xc0001a4b00, 0x17e8c98)
        github.com/opencontrol/compliance-masonry/vendor/github.com/spf13/cobra/command.go:854 +0x2c2
github.com/opencontrol/compliance-masonry/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc000021340, 0xc000010010, 0x1541ae0, 0xc000010018)
        github.com/opencontrol/compliance-masonry/vendor/github.com/spf13/cobra/command.go:958 +0x375
github.com/opencontrol/compliance-masonry/vendor/github.com/spf13/cobra.(*Command).Execute(...)
        github.com/opencontrol/compliance-masonry/vendor/github.com/spf13/cobra/command.go:895
github.com/opencontrol/compliance-masonry/pkg/cmd/masonry.Run(0xffffffff, 0xc00008c058)
        github.com/opencontrol/compliance-masonry/pkg/cmd/masonry/masonry.go:14 +0x74
main.main()
        github.com/opencontrol/compliance-masonry/cmd/masonry/masonry.go:14 +0x25
```
Fixes: #373.